### PR TITLE
refactor(core): wrap market/currency data in Arc for shared ownership

### DIFF
--- a/ccxt-exchanges/src/bitget/exchange_impl.rs
+++ b/ccxt-exchanges/src/bitget/exchange_impl.rs
@@ -97,11 +97,16 @@ impl Exchange for Bitget {
     // ==================== Market Data (Public API) ====================
 
     async fn fetch_markets(&self) -> Result<Vec<Market>> {
-        Bitget::fetch_markets(self).await
+        let arc_markets = Bitget::fetch_markets(self).await?;
+        Ok(arc_markets.into_values().map(|v| (*v).clone()).collect())
     }
 
     async fn load_markets(&self, reload: bool) -> Result<HashMap<String, Market>> {
-        Bitget::load_markets(self, reload).await
+        let arc_markets = Bitget::load_markets(self, reload).await?;
+        Ok(arc_markets
+            .into_iter()
+            .map(|(k, v)| (k, (*v).clone()))
+            .collect())
     }
 
     async fn fetch_ticker(&self, symbol: &str) -> Result<Ticker> {
@@ -237,13 +242,17 @@ impl Exchange for Bitget {
         cache
             .markets
             .get(symbol)
-            .cloned()
+            .map(|v| (**v).clone())
             .ok_or_else(|| ccxt_core::Error::bad_symbol(format!("Market {} not found", symbol)))
     }
 
     async fn markets(&self) -> HashMap<String, Market> {
         let cache = self.base().market_cache.read().await;
-        cache.markets.clone()
+        cache
+            .markets
+            .iter()
+            .map(|(k, v)| (k.clone(), (**v).clone()))
+            .collect()
     }
 }
 

--- a/ccxt-exchanges/src/bybit/ws_exchange_impl.rs
+++ b/ccxt-exchanges/src/bybit/ws_exchange_impl.rs
@@ -73,7 +73,7 @@ impl WsExchange for Bybit {
         let bybit_symbol = symbol.replace('/', "");
 
         // Try to get market info if available (optional)
-        let market = self.base().market(symbol).await.ok();
+        let market = self.base().market(symbol).await.ok().map(|m| (*m).clone());
 
         ws.watch_ticker(&bybit_symbol, market).await
     }
@@ -105,7 +105,7 @@ impl WsExchange for Bybit {
         let bybit_symbol = symbol.replace('/', "");
 
         // Try to get market info if available (optional)
-        let market = self.base().market(symbol).await.ok();
+        let market = self.base().market(symbol).await.ok().map(|m| (*m).clone());
 
         ws.watch_trades(&bybit_symbol, market).await
     }

--- a/ccxt-exchanges/src/hyperliquid/exchange_impl.rs
+++ b/ccxt-exchanges/src/hyperliquid/exchange_impl.rs
@@ -95,11 +95,16 @@ impl Exchange for HyperLiquid {
     // ==================== Market Data (Public API) ====================
 
     async fn fetch_markets(&self) -> Result<Vec<Market>> {
-        HyperLiquid::fetch_markets(self).await
+        let markets = HyperLiquid::fetch_markets(self).await?;
+        Ok(markets.into_values().map(|m| (*m).clone()).collect())
     }
 
     async fn load_markets(&self, reload: bool) -> Result<HashMap<String, Market>> {
-        HyperLiquid::load_markets(self, reload).await
+        let markets = HyperLiquid::load_markets(self, reload).await?;
+        Ok(markets
+            .into_iter()
+            .map(|(k, v)| (k, (*v).clone()))
+            .collect())
     }
 
     async fn fetch_ticker(&self, symbol: &str) -> Result<Ticker> {
@@ -204,11 +209,15 @@ impl Exchange for HyperLiquid {
     // ==================== Helper Methods ====================
 
     async fn market(&self, symbol: &str) -> Result<Market> {
-        self.base().market(symbol).await
+        self.base().market(symbol).await.map(|m| (*m).clone())
     }
 
     async fn markets(&self) -> HashMap<String, Market> {
         let cache = self.base().market_cache.read().await;
-        cache.markets.clone()
+        cache
+            .markets
+            .iter()
+            .map(|(k, v)| (k.clone(), (**v).clone()))
+            .collect()
     }
 }

--- a/ccxt-exchanges/src/okx/exchange_impl.rs
+++ b/ccxt-exchanges/src/okx/exchange_impl.rs
@@ -91,11 +91,16 @@ impl Exchange for Okx {
     // ==================== Market Data (Public API) ====================
 
     async fn fetch_markets(&self) -> Result<Vec<Market>> {
-        Okx::fetch_markets(self).await
+        let markets = Okx::fetch_markets(self).await?;
+        Ok(markets.into_values().map(|m| (*m).clone()).collect())
     }
 
     async fn load_markets(&self, reload: bool) -> Result<HashMap<String, Market>> {
-        Okx::load_markets(self, reload).await
+        let arc_markets = Okx::load_markets(self, reload).await?;
+        Ok(arc_markets
+            .into_iter()
+            .map(|(k, v)| (k, (*v).clone()))
+            .collect())
     }
 
     async fn fetch_ticker(&self, symbol: &str) -> Result<Ticker> {
@@ -231,13 +236,17 @@ impl Exchange for Okx {
         cache
             .markets
             .get(symbol)
-            .cloned()
+            .map(|m| (**m).clone())
             .ok_or_else(|| ccxt_core::Error::bad_symbol(format!("Market {} not found", symbol)))
     }
 
     async fn markets(&self) -> HashMap<String, Market> {
         let cache = self.base().market_cache.read().await;
-        cache.markets.clone()
+        cache
+            .markets
+            .iter()
+            .map(|(k, v)| (k.clone(), (**v).clone()))
+            .collect()
     }
 }
 

--- a/ccxt-exchanges/src/okx/ws_exchange_impl.rs
+++ b/ccxt-exchanges/src/okx/ws_exchange_impl.rs
@@ -48,7 +48,7 @@ impl WsExchange for Okx {
         let okx_symbol = symbol.replace('/', "-");
 
         // Try to get market info if available (optional)
-        let market = self.base().market(symbol).await.ok();
+        let market = self.base().market(symbol).await.ok().map(|m| (*m).clone());
 
         ws.watch_ticker(&okx_symbol, market).await
     }
@@ -80,7 +80,7 @@ impl WsExchange for Okx {
         let okx_symbol = symbol.replace('/', "-");
 
         // Try to get market info if available (optional)
-        let market = self.base().market(symbol).await.ok();
+        let market = self.base().market(symbol).await.ok().map(|m| (*m).clone());
 
         ws.watch_trades(&okx_symbol, market).await
     }

--- a/ccxt-exchanges/tests/binance_integration_test.rs
+++ b/ccxt-exchanges/tests/binance_integration_test.rs
@@ -68,7 +68,7 @@ async fn test_fetch_markets_real() {
         markets.len()
     );
 
-    let btc_usdt = markets.iter().find(|m| m.symbol == "BTC/USDT");
+    let btc_usdt = markets.values().find(|m| m.symbol == "BTC/USDT");
     assert!(btc_usdt.is_some(), "BTC/USDT market not found");
 
     if let Some(market) = btc_usdt {
@@ -284,7 +284,7 @@ async fn test_market_validation() {
     assert!(result.is_ok());
     let markets = result.unwrap();
 
-    for market in markets.iter().take(10) {
+    for market in markets.values().take(10) {
         assert!(!market.symbol.is_empty(), "Symbol should not be empty");
         assert!(!market.base.is_empty(), "Base currency should not be empty");
         assert!(

--- a/ccxt-exchanges/tests/bybit_integration_test.rs
+++ b/ccxt-exchanges/tests/bybit_integration_test.rs
@@ -135,7 +135,7 @@ async fn test_fetch_markets() {
     );
 
     // Check for common trading pair
-    let btc_usdt = markets.iter().find(|m| m.symbol == "BTC/USDT");
+    let btc_usdt = markets.values().find(|m| m.symbol == "BTC/USDT");
     assert!(btc_usdt.is_some(), "BTC/USDT market not found");
 
     if let Some(market) = btc_usdt {

--- a/ccxt-exchanges/tests/hyperliquid_integration_test.rs
+++ b/ccxt-exchanges/tests/hyperliquid_integration_test.rs
@@ -94,7 +94,7 @@ async fn test_fetch_markets() {
 
     assert!(!markets.is_empty(), "Should have at least one market");
 
-    for market in &markets {
+    for market in markets.values() {
         // All HyperLiquid markets should be perpetual contracts
         assert!(
             market.symbol.ends_with("/USDC:USDC"),

--- a/ccxt-exchanges/tests/okx_integration_test.rs
+++ b/ccxt-exchanges/tests/okx_integration_test.rs
@@ -110,7 +110,7 @@ async fn test_fetch_markets() {
     );
 
     // Check for common trading pair
-    let btc_usdt = markets.iter().find(|m| m.symbol == "BTC/USDT");
+    let btc_usdt = markets.values().find(|m| m.symbol == "BTC/USDT");
     assert!(btc_usdt.is_some(), "BTC/USDT market not found");
 
     if let Some(market) = btc_usdt {

--- a/examples/binance_example.rs
+++ b/examples/binance_example.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     match exchange.fetch_markets().await {
         Ok(markets) => {
             println!("   Found {} markets", markets.len());
-            if let Some(market) = markets.first() {
+            if let Some(market) = markets.values().next() {
                 println!(
                     "   Example market: {} ({}/{})",
                     market.symbol, market.base, market.quote
@@ -197,7 +197,7 @@ async fn main() -> Result<()> {
 
             // Find perpetual futures (symbols ending with /USDT)
             let perpetuals: Vec<_> = markets
-                .iter()
+                .values()
                 .filter(|m| m.symbol.contains("/USDT") && m.symbol.contains("PERP"))
                 .take(5)
                 .collect();

--- a/examples/binance_futures_example.rs
+++ b/examples/binance_futures_example.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
 
             // Find perpetual futures (symbols ending with /USDT)
             let perpetuals: Vec<_> = markets
-                .iter()
+                .values()
                 .filter(|m| m.symbol.contains("/USDT"))
                 .take(10)
                 .collect();

--- a/examples/bybit_example.rs
+++ b/examples/bybit_example.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Display first 5 markets
     println!("Sample markets:");
-    for market in markets.iter().take(5) {
+    for market in markets.values().take(5) {
         println!(
             "  {} - Base: {}, Quote: {}, Active: {}",
             market.symbol, market.base, market.quote, market.active

--- a/examples/hyperliquid_example.rs
+++ b/examples/hyperliquid_example.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Display first 5 markets
     println!("Sample markets:");
-    for market in markets.iter().take(5) {
+    for market in markets.values().take(5) {
         println!(
             "  {} - Base: {}, Quote: {}, Active: {}",
             market.symbol, market.base, market.quote, market.active

--- a/examples/okx_example.rs
+++ b/examples/okx_example.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Display first 5 markets
     println!("Sample markets:");
-    for market in markets.iter().take(5) {
+    for market in markets.values().take(5) {
         println!(
             "  {} - Base: {}, Quote: {}, Active: {}",
             market.symbol, market.base, market.quote, market.active

--- a/tests/integration/binance/test_public_api.rs
+++ b/tests/integration/binance/test_public_api.rs
@@ -46,7 +46,7 @@ async fn test_fetch_markets() -> anyhow::Result<()> {
     assert!(markets.len() < 10000, "Should have less than 10000 markets");
 
     // 验证几个主要交易对存在
-    let symbols: Vec<String> = markets.iter().map(|m| m.symbol.to_string()).collect();
+    let symbols: Vec<String> = markets.values().map(|m| m.symbol.to_string()).collect();
     assert!(
         symbols.contains(&"BTC/USDT".to_string()),
         "Should contain BTC/USDT"
@@ -57,7 +57,7 @@ async fn test_fetch_markets() -> anyhow::Result<()> {
     );
 
     // 验证第一个市场的数据完整性
-    if let Some(first_market) = markets.first() {
+    if let Some(first_market) = markets.values().next() {
         // 暂时注释掉宏调用，使用手动验证
         // assert_valid_market!(first_market);
         assert!(!first_market.symbol.to_string().is_empty());
@@ -67,11 +67,11 @@ async fn test_fetch_markets() -> anyhow::Result<()> {
 
     // 统计市场类型
     let spot_count = markets
-        .iter()
+        .values()
         .filter(|m| matches!(m.market_type, MarketType::Spot))
         .count();
     let future_count = markets
-        .iter()
+        .values()
         .filter(|m| matches!(m.market_type, MarketType::Futures))
         .count();
     println!(


### PR DESCRIPTION
- Changed MarketCache fields to store Arc<Market> and Arc<Currency>
- Removed separate rate_limiter field from BaseExchange
- Updated load_markets_with_loader to return HashMap<String, Arc<Market>>
- Modified set_markets to wrap Market/Currency in Arc during caching
- Adjusted market/market_by_id/currency methods to return Arc-wrapped data
- Deprecated throttle() method as rate limiting is now handled internally
- Updated examples and tests to work with Arc-wrapped market data
- Fixed iterator usage in examples to use .values() instead of .iter()