### PR TITLE
feat(core): add endpoint type enum and router traits for exchange APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ go/
 .roomodes
 .kiro/
 .roo/
+.specify/
 _bmad/
 docs/
 AGENTS.md

--- a/ccxt-core/src/lib.rs
+++ b/ccxt-core/src/lib.rs
@@ -132,10 +132,10 @@ pub use ws_exchange::{FullExchange, MessageStream, WsExchange};
 pub use error::ErrorContext;
 pub use types::{
     Amount, Balance, BalanceEntry, Cost, Currency, CurrencyNetwork, DefaultSubType, DefaultType,
-    DefaultTypeError, Fee, Market, MarketLimits, MarketPrecision, MarketType, MinMax, Ohlcv, Order,
-    OrderBook, OrderBookEntry, OrderBookSide, OrderSide, OrderStatus, OrderType, PrecisionMode,
-    Price, TakerOrMaker, Ticker, TickerParams, TickerParamsBuilder, Timeframe, Trade,
-    TradingLimits, resolve_market_type,
+    DefaultTypeError, EndpointType, Fee, Market, MarketLimits, MarketPrecision, MarketType, MinMax,
+    Ohlcv, Order, OrderBook, OrderBookEntry, OrderBookSide, OrderSide, OrderStatus, OrderType,
+    PrecisionMode, Price, TakerOrMaker, Ticker, TickerParams, TickerParamsBuilder, Timeframe,
+    Trade, TradingLimits, resolve_market_type,
 };
 // Re-export symbol types for unified symbol format
 pub use symbol::{SymbolError, SymbolFormatter, SymbolParser};
@@ -180,10 +180,10 @@ pub mod prelude {
     };
     pub use crate::types::{
         Amount, Balance, BalanceEntry, Currency, DefaultSubType, DefaultType, DefaultTypeError,
-        Fee, Market, MarketLimits, MarketPrecision, MarketType, Ohlcv, Order, OrderBook,
-        OrderBookEntry, OrderBookSide, OrderSide, OrderStatus, OrderType, PrecisionMode, Price,
-        Symbol, TakerOrMaker, Ticker, TickerParams, TickerParamsBuilder, Timeframe, Timestamp,
-        Trade, TradingLimits, resolve_market_type,
+        EndpointType, Fee, Market, MarketLimits, MarketPrecision, MarketType, Ohlcv, Order,
+        OrderBook, OrderBookEntry, OrderBookSide, OrderSide, OrderStatus, OrderType, PrecisionMode,
+        Price, Symbol, TakerOrMaker, Ticker, TickerParams, TickerParamsBuilder, Timeframe,
+        Timestamp, Trade, TradingLimits, resolve_market_type,
     };
     // Symbol types for unified symbol format
     pub use crate::symbol::{SymbolError, SymbolFormatter, SymbolParser};

--- a/ccxt-core/src/types/endpoint.rs
+++ b/ccxt-core/src/types/endpoint.rs
@@ -1,0 +1,153 @@
+//! Endpoint type definitions for exchange API routing
+//!
+//! This module provides the `EndpointType` enum used to distinguish between
+//! public and private API endpoints across all exchanges.
+
+use serde::{Deserialize, Serialize};
+
+/// Endpoint type enum for distinguishing between public and private API endpoints.
+///
+/// This enum is used by exchange-specific endpoint router traits to determine
+/// which API endpoint to use for a given request.
+///
+/// # Examples
+///
+/// ```rust
+/// use ccxt_core::types::EndpointType;
+///
+/// let public_endpoint = EndpointType::Public;
+/// let private_endpoint = EndpointType::Private;
+///
+/// assert_ne!(public_endpoint, private_endpoint);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub enum EndpointType {
+    /// Public API endpoint (no authentication required)
+    ///
+    /// Used for accessing publicly available data such as:
+    /// - Market information
+    /// - Ticker data
+    /// - Order book data
+    /// - Recent trades
+    #[default]
+    Public,
+
+    /// Private API endpoint (authentication required)
+    ///
+    /// Used for accessing user-specific data and operations such as:
+    /// - Account balances
+    /// - Order management
+    /// - Trade history
+    /// - Withdrawals
+    Private,
+}
+
+impl EndpointType {
+    /// Returns `true` if this is a public endpoint.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ccxt_core::types::EndpointType;
+    ///
+    /// assert!(EndpointType::Public.is_public());
+    /// assert!(!EndpointType::Private.is_public());
+    /// ```
+    #[inline]
+    pub const fn is_public(&self) -> bool {
+        matches!(self, Self::Public)
+    }
+
+    /// Returns `true` if this is a private endpoint.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ccxt_core::types::EndpointType;
+    ///
+    /// assert!(EndpointType::Private.is_private());
+    /// assert!(!EndpointType::Public.is_private());
+    /// ```
+    #[inline]
+    pub const fn is_private(&self) -> bool {
+        matches!(self, Self::Private)
+    }
+}
+
+impl std::fmt::Display for EndpointType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Public => write!(f, "public"),
+            Self::Private => write!(f, "private"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_endpoint_type_equality() {
+        assert_eq!(EndpointType::Public, EndpointType::Public);
+        assert_eq!(EndpointType::Private, EndpointType::Private);
+        assert_ne!(EndpointType::Public, EndpointType::Private);
+    }
+
+    #[test]
+    fn test_endpoint_type_is_public() {
+        assert!(EndpointType::Public.is_public());
+        assert!(!EndpointType::Private.is_public());
+    }
+
+    #[test]
+    fn test_endpoint_type_is_private() {
+        assert!(EndpointType::Private.is_private());
+        assert!(!EndpointType::Public.is_private());
+    }
+
+    #[test]
+    fn test_endpoint_type_display() {
+        assert_eq!(format!("{}", EndpointType::Public), "public");
+        assert_eq!(format!("{}", EndpointType::Private), "private");
+    }
+
+    #[test]
+    fn test_endpoint_type_default() {
+        assert_eq!(EndpointType::default(), EndpointType::Public);
+    }
+
+    #[test]
+    fn test_endpoint_type_clone() {
+        let original = EndpointType::Private;
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn test_endpoint_type_copy() {
+        let original = EndpointType::Public;
+        let copied = original;
+        assert_eq!(original, copied);
+    }
+
+    #[test]
+    fn test_endpoint_type_hash() {
+        use std::collections::HashSet;
+
+        let mut set = HashSet::new();
+        set.insert(EndpointType::Public);
+        set.insert(EndpointType::Private);
+        set.insert(EndpointType::Public); // Duplicate
+
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&EndpointType::Public));
+        assert!(set.contains(&EndpointType::Private));
+    }
+
+    #[test]
+    fn test_endpoint_type_debug() {
+        assert_eq!(format!("{:?}", EndpointType::Public), "Public");
+        assert_eq!(format!("{:?}", EndpointType::Private), "Private");
+    }
+}

--- a/ccxt-core/src/types/mod.rs
+++ b/ccxt-core/src/types/mod.rs
@@ -14,6 +14,8 @@ pub mod bid_ask;
 pub mod currency;
 /// Default type configuration for exchange operations
 pub mod default_type;
+/// Endpoint type for public/private API distinction
+pub mod endpoint;
 pub mod fee;
 /// Financial types with enhanced type safety (Price, Amount, Cost)
 pub mod financial;
@@ -47,6 +49,7 @@ pub use balance::{Balance, BalanceEntry, MaxBorrowable, MaxTransferable};
 pub use bid_ask::BidAsk;
 pub use currency::{Currency, CurrencyNetwork, MinMax, PrecisionMode};
 pub use default_type::{DefaultSubType, DefaultType, DefaultTypeError, resolve_market_type};
+pub use endpoint::EndpointType;
 pub use fee::{
     FundingRate as FeeFundingRate, FundingRateHistory as FeeFundingRateHistory, LeverageTier,
     TradingFee as FeeTradingFee,

--- a/ccxt-exchanges/src/binance/endpoint_router.rs
+++ b/ccxt-exchanges/src/binance/endpoint_router.rs
@@ -1,0 +1,669 @@
+//! Binance-specific endpoint router trait.
+//!
+//! This module provides the `BinanceEndpointRouter` trait for routing API requests
+//! to the correct Binance domain based on market characteristics.
+//!
+//! # Binance API Domains
+//!
+//! Binance has a complex multi-domain structure:
+//! - **Spot**: `api.binance.com` - Spot trading and margin
+//! - **Linear Futures (FAPI)**: `fapi.binance.com` - USDT-margined perpetuals/futures
+//! - **Inverse Futures (DAPI)**: `dapi.binance.com` - Coin-margined perpetuals/futures
+//! - **Options (EAPI)**: `eapi.binance.com` - Options trading
+//! - **Portfolio Margin (PAPI)**: `papi.binance.com` - Portfolio margin API
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use ccxt_exchanges::binance::{Binance, BinanceEndpointRouter};
+//! use ccxt_core::types::{EndpointType, Market, MarketType};
+//! use ccxt_core::ExchangeConfig;
+//!
+//! let binance = Binance::new(ExchangeConfig::default()).unwrap();
+//!
+//! // Get REST endpoint for a spot market
+//! let spot_market = Market::new_spot(
+//!     "BTCUSDT".to_string(),
+//!     "BTC/USDT".to_string(),
+//!     "BTC".to_string(),
+//!     "USDT".to_string(),
+//! );
+//! let url = binance.rest_endpoint(&spot_market, EndpointType::Public);
+//! assert!(url.contains("api.binance.com"));
+//!
+//! // Get default REST endpoint based on exchange options
+//! let default_url = binance.default_rest_endpoint(EndpointType::Public);
+//! ```
+
+use ccxt_core::types::{EndpointType, Market, MarketType};
+
+/// Binance-specific endpoint router trait.
+///
+/// This trait defines methods for obtaining the correct API endpoints based on
+/// market characteristics. Binance has multiple API domains for different market
+/// types (spot, linear futures, inverse futures, options).
+///
+/// # Implementation Notes
+///
+/// The routing logic follows these rules:
+/// - **Spot markets**: Use `api.binance.com` endpoints
+/// - **Linear Swap/Futures**: Use `fapi.binance.com` endpoints (USDT-margined)
+/// - **Inverse Swap/Futures**: Use `dapi.binance.com` endpoints (Coin-margined)
+/// - **Option markets**: Use `eapi.binance.com` endpoints
+///
+/// When sandbox mode is enabled, testnet URLs are returned instead.
+pub trait BinanceEndpointRouter {
+    /// Returns the REST API endpoint for a specific market.
+    ///
+    /// This method routes to the correct Binance domain based on the market's
+    /// `market_type`, `linear`, and `inverse` fields.
+    ///
+    /// # Arguments
+    ///
+    /// * `market` - Reference to the market object containing type information
+    /// * `endpoint_type` - Whether this is a public or private endpoint
+    ///
+    /// # Returns
+    ///
+    /// The REST API base URL string for the given market.
+    ///
+    /// # Routing Logic
+    ///
+    /// | Market Type | Linear | Inverse | Domain |
+    /// |-------------|--------|---------|--------|
+    /// | Spot | - | - | api.binance.com |
+    /// | Swap/Futures | true | false | fapi.binance.com |
+    /// | Swap/Futures | false | true | dapi.binance.com |
+    /// | Option | - | - | eapi.binance.com |
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::binance::{Binance, BinanceEndpointRouter};
+    /// use ccxt_core::types::{EndpointType, Market, MarketType};
+    /// use ccxt_core::ExchangeConfig;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// let binance = Binance::new(ExchangeConfig::default()).unwrap();
+    ///
+    /// // Linear futures market
+    /// let linear_market = Market::new_swap(
+    ///     "BTCUSDT".to_string(),
+    ///     "BTC/USDT:USDT".to_string(),
+    ///     "BTC".to_string(),
+    ///     "USDT".to_string(),
+    ///     "USDT".to_string(),
+    ///     dec!(1.0),
+    /// );
+    /// let url = binance.rest_endpoint(&linear_market, EndpointType::Public);
+    /// assert!(url.contains("fapi.binance.com"));
+    /// ```
+    fn rest_endpoint(&self, market: &Market, endpoint_type: EndpointType) -> String;
+
+    /// Returns the WebSocket endpoint for a specific market.
+    ///
+    /// This method routes to the correct Binance WebSocket domain based on
+    /// the market's type and settlement characteristics.
+    ///
+    /// # Arguments
+    ///
+    /// * `market` - Reference to the market object containing type information
+    ///
+    /// # Returns
+    ///
+    /// The WebSocket URL string for the given market.
+    ///
+    /// # Routing Logic
+    ///
+    /// | Market Type | Linear | Inverse | WebSocket Domain |
+    /// |-------------|--------|---------|------------------|
+    /// | Spot | - | - | stream.binance.com |
+    /// | Swap/Futures | true | false | fstream.binance.com |
+    /// | Swap/Futures | false | true | dstream.binance.com |
+    /// | Option | - | - | nbstream.binance.com |
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::binance::{Binance, BinanceEndpointRouter};
+    /// use ccxt_core::types::Market;
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let binance = Binance::new(ExchangeConfig::default()).unwrap();
+    ///
+    /// let spot_market = Market::new_spot(
+    ///     "BTCUSDT".to_string(),
+    ///     "BTC/USDT".to_string(),
+    ///     "BTC".to_string(),
+    ///     "USDT".to_string(),
+    /// );
+    /// let ws_url = binance.ws_endpoint(&spot_market);
+    /// assert!(ws_url.contains("stream.binance.com"));
+    /// ```
+    fn ws_endpoint(&self, market: &Market) -> String;
+
+    /// Returns the default REST endpoint when no specific market is provided.
+    ///
+    /// This method uses the exchange's `default_type` and `default_sub_type`
+    /// options to determine which endpoint to return.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint_type` - Whether this is a public or private endpoint
+    ///
+    /// # Returns
+    ///
+    /// The default REST API base URL string.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::binance::{Binance, BinanceEndpointRouter, BinanceOptions};
+    /// use ccxt_core::types::EndpointType;
+    /// use ccxt_core::types::default_type::{DefaultType, DefaultSubType};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// // Create a futures-focused Binance instance
+    /// let options = BinanceOptions {
+    ///     default_type: DefaultType::Swap,
+    ///     default_sub_type: Some(DefaultSubType::Linear),
+    ///     ..Default::default()
+    /// };
+    /// let binance = Binance::new_with_options(ExchangeConfig::default(), options).unwrap();
+    ///
+    /// let url = binance.default_rest_endpoint(EndpointType::Public);
+    /// assert!(url.contains("fapi.binance.com"));
+    /// ```
+    fn default_rest_endpoint(&self, endpoint_type: EndpointType) -> String;
+
+    /// Returns the default WebSocket endpoint when no specific market is provided.
+    ///
+    /// This method uses the exchange's `default_type` and `default_sub_type`
+    /// options to determine which WebSocket endpoint to return.
+    ///
+    /// # Returns
+    ///
+    /// The default WebSocket URL string.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::binance::{Binance, BinanceEndpointRouter};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let binance = Binance::new(ExchangeConfig::default()).unwrap();
+    /// let ws_url = binance.default_ws_endpoint();
+    /// // Default is spot, so should be stream.binance.com
+    /// assert!(ws_url.contains("stream.binance.com"));
+    /// ```
+    fn default_ws_endpoint(&self) -> String;
+
+    /// Returns the SAPI (Spot API) endpoint.
+    ///
+    /// SAPI is used for Binance-specific spot trading features like:
+    /// - Margin trading operations
+    /// - Savings and staking
+    /// - Sub-account management
+    /// - Asset transfers
+    ///
+    /// # Returns
+    ///
+    /// The SAPI base URL string.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::binance::{Binance, BinanceEndpointRouter};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let binance = Binance::new(ExchangeConfig::default()).unwrap();
+    /// let sapi_url = binance.sapi_endpoint();
+    /// assert!(sapi_url.contains("sapi"));
+    /// ```
+    fn sapi_endpoint(&self) -> String;
+
+    /// Returns the Portfolio Margin API (PAPI) endpoint.
+    ///
+    /// PAPI is used for portfolio margin trading which allows cross-margining
+    /// across spot, futures, and options positions.
+    ///
+    /// # Returns
+    ///
+    /// The PAPI base URL string.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::binance::{Binance, BinanceEndpointRouter};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let binance = Binance::new(ExchangeConfig::default()).unwrap();
+    /// let papi_url = binance.papi_endpoint();
+    /// assert!(papi_url.contains("papi"));
+    /// ```
+    fn papi_endpoint(&self) -> String;
+}
+
+use super::Binance;
+
+use ccxt_core::types::default_type::{DefaultSubType, DefaultType};
+
+impl BinanceEndpointRouter for Binance {
+    fn rest_endpoint(&self, market: &Market, endpoint_type: EndpointType) -> String {
+        let urls = self.urls();
+
+        match market.market_type {
+            MarketType::Spot => match endpoint_type {
+                EndpointType::Public => urls.public.clone(),
+                EndpointType::Private => urls.private.clone(),
+            },
+            MarketType::Swap | MarketType::Futures => {
+                // Determine linear/inverse from market fields
+                // Default to linear (true) if not specified
+                let is_linear = market.linear.unwrap_or(true);
+
+                if is_linear {
+                    match endpoint_type {
+                        EndpointType::Public => urls.fapi_public.clone(),
+                        EndpointType::Private => urls.fapi_private.clone(),
+                    }
+                } else {
+                    match endpoint_type {
+                        EndpointType::Public => urls.dapi_public.clone(),
+                        EndpointType::Private => urls.dapi_private.clone(),
+                    }
+                }
+            }
+            MarketType::Option => match endpoint_type {
+                EndpointType::Public => urls.eapi_public.clone(),
+                EndpointType::Private => urls.eapi_private.clone(),
+            },
+        }
+    }
+
+    fn ws_endpoint(&self, market: &Market) -> String {
+        let urls = self.urls();
+
+        match market.market_type {
+            MarketType::Spot => urls.ws.clone(),
+            MarketType::Swap | MarketType::Futures => {
+                // Determine linear/inverse from market fields
+                // Default to linear (true) if not specified
+                let is_linear = market.linear.unwrap_or(true);
+
+                if is_linear {
+                    urls.ws_fapi.clone()
+                } else {
+                    urls.ws_dapi.clone()
+                }
+            }
+            MarketType::Option => urls.ws_eapi.clone(),
+        }
+    }
+
+    fn default_rest_endpoint(&self, endpoint_type: EndpointType) -> String {
+        let urls = self.urls();
+        let options = self.options();
+
+        match options.default_type {
+            DefaultType::Spot => match endpoint_type {
+                EndpointType::Public => urls.public.clone(),
+                EndpointType::Private => urls.private.clone(),
+            },
+            DefaultType::Margin => urls.sapi.clone(),
+            DefaultType::Swap | DefaultType::Futures => {
+                match options.default_sub_type {
+                    Some(DefaultSubType::Inverse) => match endpoint_type {
+                        EndpointType::Public => urls.dapi_public.clone(),
+                        EndpointType::Private => urls.dapi_private.clone(),
+                    },
+                    _ => match endpoint_type {
+                        // Default to FAPI (Linear)
+                        EndpointType::Public => urls.fapi_public.clone(),
+                        EndpointType::Private => urls.fapi_private.clone(),
+                    },
+                }
+            }
+            DefaultType::Option => match endpoint_type {
+                EndpointType::Public => urls.eapi_public.clone(),
+                EndpointType::Private => urls.eapi_private.clone(),
+            },
+        }
+    }
+
+    fn default_ws_endpoint(&self) -> String {
+        let urls = self.urls();
+        let options = self.options();
+
+        match options.default_type {
+            DefaultType::Swap | DefaultType::Futures => {
+                // Check sub-type for FAPI vs DAPI selection
+                match options.default_sub_type {
+                    Some(DefaultSubType::Inverse) => urls.ws_dapi.clone(),
+                    _ => urls.ws_fapi.clone(), // Default to FAPI (Linear) if not specified
+                }
+            }
+            DefaultType::Option => urls.ws_eapi.clone(),
+            _ => urls.ws.clone(), // Spot and Margin use standard WebSocket
+        }
+    }
+
+    fn sapi_endpoint(&self) -> String {
+        self.urls().sapi.clone()
+    }
+
+    fn papi_endpoint(&self) -> String {
+        self.urls().papi.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccxt_core::ExchangeConfig;
+    use rust_decimal_macros::dec;
+
+    fn create_test_binance() -> Binance {
+        Binance::new(ExchangeConfig::default()).unwrap()
+    }
+
+    fn create_sandbox_binance() -> Binance {
+        let config = ExchangeConfig {
+            sandbox: true,
+            ..Default::default()
+        };
+        Binance::new(config).unwrap()
+    }
+
+    // ==================== REST Endpoint Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_spot_public() {
+        let binance = create_test_binance();
+        let market = Market::new_spot(
+            "BTCUSDT".to_string(),
+            "BTC/USDT".to_string(),
+            "BTC".to_string(),
+            "USDT".to_string(),
+        );
+
+        let url = binance.rest_endpoint(&market, EndpointType::Public);
+        assert!(url.contains("api.binance.com"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_spot_private() {
+        let binance = create_test_binance();
+        let market = Market::new_spot(
+            "BTCUSDT".to_string(),
+            "BTC/USDT".to_string(),
+            "BTC".to_string(),
+            "USDT".to_string(),
+        );
+
+        let url = binance.rest_endpoint(&market, EndpointType::Private);
+        assert!(url.contains("api.binance.com"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_linear_swap_public() {
+        let binance = create_test_binance();
+        let market = Market::new_swap(
+            "BTCUSDT".to_string(),
+            "BTC/USDT:USDT".to_string(),
+            "BTC".to_string(),
+            "USDT".to_string(),
+            "USDT".to_string(),
+            dec!(1.0),
+        );
+
+        let url = binance.rest_endpoint(&market, EndpointType::Public);
+        assert!(url.contains("fapi.binance.com"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_linear_swap_private() {
+        let binance = create_test_binance();
+        let market = Market::new_swap(
+            "BTCUSDT".to_string(),
+            "BTC/USDT:USDT".to_string(),
+            "BTC".to_string(),
+            "USDT".to_string(),
+            "USDT".to_string(),
+            dec!(1.0),
+        );
+
+        let url = binance.rest_endpoint(&market, EndpointType::Private);
+        assert!(url.contains("fapi.binance.com"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_inverse_swap_public() {
+        let binance = create_test_binance();
+        let mut market = Market::new_swap(
+            "BTCUSD_PERP".to_string(),
+            "BTC/USD:BTC".to_string(),
+            "BTC".to_string(),
+            "USD".to_string(),
+            "BTC".to_string(),
+            dec!(100.0),
+        );
+        // Ensure inverse is set correctly
+        market.linear = Some(false);
+        market.inverse = Some(true);
+
+        let url = binance.rest_endpoint(&market, EndpointType::Public);
+        assert!(url.contains("dapi.binance.com"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_inverse_swap_private() {
+        let binance = create_test_binance();
+        let mut market = Market::new_swap(
+            "BTCUSD_PERP".to_string(),
+            "BTC/USD:BTC".to_string(),
+            "BTC".to_string(),
+            "USD".to_string(),
+            "BTC".to_string(),
+            dec!(100.0),
+        );
+        market.linear = Some(false);
+        market.inverse = Some(true);
+
+        let url = binance.rest_endpoint(&market, EndpointType::Private);
+        assert!(url.contains("dapi.binance.com"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_option_public() {
+        let binance = create_test_binance();
+        let mut market = Market::default();
+        market.id = "BTC-250328-100000-C".to_string();
+        market.symbol = "BTC/USDT:USDT-250328-100000-C".to_string();
+        market.market_type = MarketType::Option;
+
+        let url = binance.rest_endpoint(&market, EndpointType::Public);
+        assert!(url.contains("eapi.binance.com"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_option_private() {
+        let binance = create_test_binance();
+        let mut market = Market::default();
+        market.id = "BTC-250328-100000-C".to_string();
+        market.symbol = "BTC/USDT:USDT-250328-100000-C".to_string();
+        market.market_type = MarketType::Option;
+
+        let url = binance.rest_endpoint(&market, EndpointType::Private);
+        assert!(url.contains("eapi.binance.com"));
+    }
+
+    // ==================== WebSocket Endpoint Tests ====================
+
+    #[test]
+    fn test_ws_endpoint_spot() {
+        let binance = create_test_binance();
+        let market = Market::new_spot(
+            "BTCUSDT".to_string(),
+            "BTC/USDT".to_string(),
+            "BTC".to_string(),
+            "USDT".to_string(),
+        );
+
+        let url = binance.ws_endpoint(&market);
+        assert!(url.contains("stream.binance.com"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_linear_swap() {
+        let binance = create_test_binance();
+        let market = Market::new_swap(
+            "BTCUSDT".to_string(),
+            "BTC/USDT:USDT".to_string(),
+            "BTC".to_string(),
+            "USDT".to_string(),
+            "USDT".to_string(),
+            dec!(1.0),
+        );
+
+        let url = binance.ws_endpoint(&market);
+        assert!(url.contains("fstream.binance.com"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_inverse_swap() {
+        let binance = create_test_binance();
+        let mut market = Market::new_swap(
+            "BTCUSD_PERP".to_string(),
+            "BTC/USD:BTC".to_string(),
+            "BTC".to_string(),
+            "USD".to_string(),
+            "BTC".to_string(),
+            dec!(100.0),
+        );
+        market.linear = Some(false);
+        market.inverse = Some(true);
+
+        let url = binance.ws_endpoint(&market);
+        assert!(url.contains("dstream.binance.com"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_option() {
+        let binance = create_test_binance();
+        let mut market = Market::default();
+        market.market_type = MarketType::Option;
+
+        let url = binance.ws_endpoint(&market);
+        assert!(url.contains("nbstream.binance.com"));
+    }
+
+    // ==================== Default Endpoint Tests ====================
+
+    #[test]
+    fn test_default_rest_endpoint_spot() {
+        let binance = create_test_binance();
+
+        let url = binance.default_rest_endpoint(EndpointType::Public);
+        assert!(url.contains("api.binance.com"));
+    }
+
+    #[test]
+    fn test_default_ws_endpoint_spot() {
+        let binance = create_test_binance();
+
+        let url = binance.default_ws_endpoint();
+        assert!(url.contains("stream.binance.com"));
+    }
+
+    // ==================== SAPI and PAPI Tests ====================
+
+    #[test]
+    fn test_sapi_endpoint() {
+        let binance = create_test_binance();
+
+        let url = binance.sapi_endpoint();
+        assert!(url.contains("sapi"));
+        assert!(url.contains("api.binance.com"));
+    }
+
+    #[test]
+    fn test_papi_endpoint() {
+        let binance = create_test_binance();
+
+        let url = binance.papi_endpoint();
+        assert!(url.contains("papi"));
+    }
+
+    // ==================== Sandbox Mode Tests ====================
+
+    #[test]
+    fn test_sandbox_rest_endpoint_spot() {
+        let binance = create_sandbox_binance();
+        let market = Market::new_spot(
+            "BTCUSDT".to_string(),
+            "BTC/USDT".to_string(),
+            "BTC".to_string(),
+            "USDT".to_string(),
+        );
+
+        let url = binance.rest_endpoint(&market, EndpointType::Public);
+        assert!(url.contains("testnet"));
+    }
+
+    #[test]
+    fn test_sandbox_ws_endpoint_spot() {
+        let binance = create_sandbox_binance();
+        let market = Market::new_spot(
+            "BTCUSDT".to_string(),
+            "BTC/USDT".to_string(),
+            "BTC".to_string(),
+            "USDT".to_string(),
+        );
+
+        let url = binance.ws_endpoint(&market);
+        assert!(url.contains("testnet"));
+    }
+
+    #[test]
+    fn test_sandbox_rest_endpoint_linear_swap() {
+        let binance = create_sandbox_binance();
+        let market = Market::new_swap(
+            "BTCUSDT".to_string(),
+            "BTC/USDT:USDT".to_string(),
+            "BTC".to_string(),
+            "USDT".to_string(),
+            "USDT".to_string(),
+            dec!(1.0),
+        );
+
+        let url = binance.rest_endpoint(&market, EndpointType::Public);
+        assert!(url.contains("testnet"));
+    }
+
+    // ==================== Edge Case Tests ====================
+
+    #[test]
+    fn test_swap_defaults_to_linear_when_not_specified() {
+        let binance = create_test_binance();
+        let mut market = Market::default();
+        market.market_type = MarketType::Swap;
+        // linear and inverse are None
+
+        let url = binance.rest_endpoint(&market, EndpointType::Public);
+        // Should default to linear (fapi)
+        assert!(url.contains("fapi.binance.com"));
+    }
+
+    #[test]
+    fn test_futures_defaults_to_linear_when_not_specified() {
+        let binance = create_test_binance();
+        let mut market = Market::default();
+        market.market_type = MarketType::Futures;
+        // linear and inverse are None
+
+        let url = binance.rest_endpoint(&market, EndpointType::Public);
+        // Should default to linear (fapi)
+        assert!(url.contains("fapi.binance.com"));
+    }
+}

--- a/ccxt-exchanges/src/bitget/endpoint_router.rs
+++ b/ccxt-exchanges/src/bitget/endpoint_router.rs
@@ -1,0 +1,365 @@
+//! Bitget-specific endpoint router trait.
+//!
+//! This module provides the `BitgetEndpointRouter` trait for routing API requests
+//! to the correct Bitget endpoints based on endpoint type (public/private).
+//!
+//! # Bitget API Structure
+//!
+//! Bitget uses a simple dual-endpoint structure:
+//! - **REST**: `api.bitget.com` - Single REST endpoint for all operations
+//! - **WebSocket Public**: `ws.bitget.com/v2/ws/public` - Public market data
+//! - **WebSocket Private**: `ws.bitget.com/v2/ws/private` - Account data
+//!
+//! # Testnet/Sandbox Mode
+//!
+//! Bitget provides a separate testnet environment:
+//! - REST: `api-testnet.bitget.com`
+//! - WS Public: `ws-testnet.bitget.com/v2/ws/public`
+//! - WS Private: `ws-testnet.bitget.com/v2/ws/private`
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use ccxt_exchanges::bitget::{Bitget, BitgetEndpointRouter};
+//! use ccxt_core::types::EndpointType;
+//! use ccxt_core::ExchangeConfig;
+//!
+//! let bitget = Bitget::new(ExchangeConfig::default()).unwrap();
+//!
+//! // Get REST endpoint
+//! let rest_url = bitget.rest_endpoint();
+//! assert!(rest_url.contains("api.bitget.com"));
+//!
+//! // Get WebSocket endpoint for public data
+//! let ws_public = bitget.ws_endpoint(EndpointType::Public);
+//! assert!(ws_public.contains("/v2/ws/public"));
+//!
+//! // Get WebSocket endpoint for private data
+//! let ws_private = bitget.ws_endpoint(EndpointType::Private);
+//! assert!(ws_private.contains("/v2/ws/private"));
+//! ```
+
+use ccxt_core::types::EndpointType;
+
+/// Bitget-specific endpoint router trait.
+///
+/// This trait defines methods for obtaining the correct API endpoints for Bitget.
+/// Bitget uses a simple structure with separate public and private WebSocket endpoints.
+///
+/// # Implementation Notes
+///
+/// - REST API uses a single domain for all operations
+/// - WebSocket has separate endpoints for public and private data
+/// - Testnet mode switches to completely different domains
+///
+/// # Sandbox/Testnet Mode
+///
+/// When sandbox mode is enabled (via `config.sandbox` or `options.testnet`):
+/// - REST URL changes to `api-testnet.bitget.com`
+/// - WebSocket URLs change to `ws-testnet.bitget.com`
+pub trait BitgetEndpointRouter {
+    /// Returns the REST API endpoint.
+    ///
+    /// Bitget uses a single REST domain for all market types and operations.
+    /// The product type (spot, umcbl, dmcbl) is specified in the API path,
+    /// not in the domain.
+    ///
+    /// # Returns
+    ///
+    /// The REST API base URL string.
+    ///
+    /// # Production vs Testnet
+    ///
+    /// - Production: `https://api.bitget.com`
+    /// - Testnet: `https://api-testnet.bitget.com`
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::bitget::{Bitget, BitgetEndpointRouter};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let bitget = Bitget::new(ExchangeConfig::default()).unwrap();
+    /// let url = bitget.rest_endpoint();
+    /// assert_eq!(url, "https://api.bitget.com");
+    /// ```
+    fn rest_endpoint(&self) -> &str;
+
+    /// Returns the WebSocket endpoint for a specific endpoint type.
+    ///
+    /// Bitget uses separate WebSocket URLs for public and private data:
+    /// - `Public`: `/v2/ws/public` - Market data (no authentication)
+    /// - `Private`: `/v2/ws/private` - Account data (authentication required)
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint_type` - The endpoint type (Public or Private)
+    ///
+    /// # Returns
+    ///
+    /// The complete WebSocket URL for the specified endpoint type.
+    ///
+    /// # Production vs Testnet
+    ///
+    /// Production:
+    /// - Public: `wss://ws.bitget.com/v2/ws/public`
+    /// - Private: `wss://ws.bitget.com/v2/ws/private`
+    ///
+    /// Testnet:
+    /// - Public: `wss://ws-testnet.bitget.com/v2/ws/public`
+    /// - Private: `wss://ws-testnet.bitget.com/v2/ws/private`
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::bitget::{Bitget, BitgetEndpointRouter};
+    /// use ccxt_core::types::EndpointType;
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let bitget = Bitget::new(ExchangeConfig::default()).unwrap();
+    ///
+    /// // Get WebSocket URL for public market data
+    /// let ws_public = bitget.ws_endpoint(EndpointType::Public);
+    /// assert!(ws_public.contains("/v2/ws/public"));
+    ///
+    /// // Get WebSocket URL for private account data
+    /// let ws_private = bitget.ws_endpoint(EndpointType::Private);
+    /// assert!(ws_private.contains("/v2/ws/private"));
+    /// ```
+    fn ws_endpoint(&self, endpoint_type: EndpointType) -> &str;
+}
+
+use super::Bitget;
+
+impl BitgetEndpointRouter for Bitget {
+    fn rest_endpoint(&self) -> &str {
+        // Return static reference based on sandbox mode
+        // This matches the pattern used by other exchanges
+        if self.is_sandbox() {
+            "https://api-testnet.bitget.com"
+        } else {
+            "https://api.bitget.com"
+        }
+    }
+
+    fn ws_endpoint(&self, endpoint_type: EndpointType) -> &str {
+        // Return static reference based on sandbox mode and endpoint type
+        if self.is_sandbox() {
+            match endpoint_type {
+                EndpointType::Public => "wss://ws-testnet.bitget.com/v2/ws/public",
+                EndpointType::Private => "wss://ws-testnet.bitget.com/v2/ws/private",
+            }
+        } else {
+            match endpoint_type {
+                EndpointType::Public => "wss://ws.bitget.com/v2/ws/public",
+                EndpointType::Private => "wss://ws.bitget.com/v2/ws/private",
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bitget::BitgetOptions;
+    use ccxt_core::ExchangeConfig;
+
+    fn create_test_bitget() -> Bitget {
+        Bitget::new(ExchangeConfig::default()).unwrap()
+    }
+
+    fn create_sandbox_bitget() -> Bitget {
+        let config = ExchangeConfig {
+            sandbox: true,
+            ..Default::default()
+        };
+        Bitget::new(config).unwrap()
+    }
+
+    // ==================== REST Endpoint Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_production() {
+        let bitget = create_test_bitget();
+        let url = bitget.rest_endpoint();
+        assert_eq!(url, "https://api.bitget.com");
+        assert!(!url.contains("testnet"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_sandbox() {
+        let bitget = create_sandbox_bitget();
+        let url = bitget.rest_endpoint();
+        assert_eq!(url, "https://api-testnet.bitget.com");
+    }
+
+    // ==================== WebSocket Public Endpoint Tests ====================
+
+    #[test]
+    fn test_ws_endpoint_public_production() {
+        let bitget = create_test_bitget();
+        let url = bitget.ws_endpoint(EndpointType::Public);
+        assert_eq!(url, "wss://ws.bitget.com/v2/ws/public");
+        assert!(!url.contains("testnet"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_public_sandbox() {
+        let bitget = create_sandbox_bitget();
+        let url = bitget.ws_endpoint(EndpointType::Public);
+        assert_eq!(url, "wss://ws-testnet.bitget.com/v2/ws/public");
+    }
+
+    // ==================== WebSocket Private Endpoint Tests ====================
+
+    #[test]
+    fn test_ws_endpoint_private_production() {
+        let bitget = create_test_bitget();
+        let url = bitget.ws_endpoint(EndpointType::Private);
+        assert_eq!(url, "wss://ws.bitget.com/v2/ws/private");
+        assert!(!url.contains("testnet"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_private_sandbox() {
+        let bitget = create_sandbox_bitget();
+        let url = bitget.ws_endpoint(EndpointType::Private);
+        assert_eq!(url, "wss://ws-testnet.bitget.com/v2/ws/private");
+    }
+
+    // ==================== Testnet Option Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_with_testnet_option() {
+        let config = ExchangeConfig::default();
+        let options = BitgetOptions {
+            testnet: true,
+            ..Default::default()
+        };
+        let bitget = Bitget::new_with_options(config, options).unwrap();
+
+        let url = bitget.rest_endpoint();
+        assert_eq!(url, "https://api-testnet.bitget.com");
+    }
+
+    #[test]
+    fn test_ws_endpoint_public_with_testnet_option() {
+        let config = ExchangeConfig::default();
+        let options = BitgetOptions {
+            testnet: true,
+            ..Default::default()
+        };
+        let bitget = Bitget::new_with_options(config, options).unwrap();
+
+        let url = bitget.ws_endpoint(EndpointType::Public);
+        assert_eq!(url, "wss://ws-testnet.bitget.com/v2/ws/public");
+    }
+
+    #[test]
+    fn test_ws_endpoint_private_with_testnet_option() {
+        let config = ExchangeConfig::default();
+        let options = BitgetOptions {
+            testnet: true,
+            ..Default::default()
+        };
+        let bitget = Bitget::new_with_options(config, options).unwrap();
+
+        let url = bitget.ws_endpoint(EndpointType::Private);
+        assert_eq!(url, "wss://ws-testnet.bitget.com/v2/ws/private");
+    }
+
+    // ==================== Consistency Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_consistency_with_urls() {
+        let bitget = create_test_bitget();
+        let router_url = bitget.rest_endpoint();
+        let urls_rest = bitget.urls().rest;
+        assert_eq!(router_url, urls_rest);
+    }
+
+    #[test]
+    fn test_ws_public_endpoint_consistency_with_urls() {
+        let bitget = create_test_bitget();
+        let router_url = bitget.ws_endpoint(EndpointType::Public);
+        let urls_ws_public = bitget.urls().ws_public;
+        assert_eq!(router_url, urls_ws_public);
+    }
+
+    #[test]
+    fn test_ws_private_endpoint_consistency_with_urls() {
+        let bitget = create_test_bitget();
+        let router_url = bitget.ws_endpoint(EndpointType::Private);
+        let urls_ws_private = bitget.urls().ws_private;
+        assert_eq!(router_url, urls_ws_private);
+    }
+
+    #[test]
+    fn test_sandbox_rest_endpoint_consistency_with_urls() {
+        let bitget = create_sandbox_bitget();
+        let router_url = bitget.rest_endpoint();
+        let urls_rest = bitget.urls().rest;
+        assert_eq!(router_url, urls_rest);
+    }
+
+    #[test]
+    fn test_sandbox_ws_public_endpoint_consistency_with_urls() {
+        let bitget = create_sandbox_bitget();
+        let router_url = bitget.ws_endpoint(EndpointType::Public);
+        let urls_ws_public = bitget.urls().ws_public;
+        assert_eq!(router_url, urls_ws_public);
+    }
+
+    #[test]
+    fn test_sandbox_ws_private_endpoint_consistency_with_urls() {
+        let bitget = create_sandbox_bitget();
+        let router_url = bitget.ws_endpoint(EndpointType::Private);
+        let urls_ws_private = bitget.urls().ws_private;
+        assert_eq!(router_url, urls_ws_private);
+    }
+
+    // ==================== Endpoint Type Tests ====================
+
+    #[test]
+    fn test_endpoint_type_public_is_public() {
+        assert!(EndpointType::Public.is_public());
+        assert!(!EndpointType::Public.is_private());
+    }
+
+    #[test]
+    fn test_endpoint_type_private_is_private() {
+        assert!(EndpointType::Private.is_private());
+        assert!(!EndpointType::Private.is_public());
+    }
+
+    // ==================== URL Format Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_uses_https() {
+        let bitget = create_test_bitget();
+        let url = bitget.rest_endpoint();
+        assert!(url.starts_with("https://"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_uses_wss() {
+        let bitget = create_test_bitget();
+
+        let ws_public = bitget.ws_endpoint(EndpointType::Public);
+        assert!(ws_public.starts_with("wss://"));
+
+        let ws_private = bitget.ws_endpoint(EndpointType::Private);
+        assert!(ws_private.starts_with("wss://"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_contains_v2_path() {
+        let bitget = create_test_bitget();
+
+        let ws_public = bitget.ws_endpoint(EndpointType::Public);
+        assert!(ws_public.contains("/v2/ws/"));
+
+        let ws_private = bitget.ws_endpoint(EndpointType::Private);
+        assert!(ws_private.contains("/v2/ws/"));
+    }
+}

--- a/ccxt-exchanges/src/bitget/mod.rs
+++ b/ccxt-exchanges/src/bitget/mod.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 
 pub mod auth;
 pub mod builder;
+pub mod endpoint_router;
 pub mod error;
 mod exchange_impl;
 pub mod parser;
@@ -18,6 +19,7 @@ mod ws_exchange_impl;
 
 pub use auth::BitgetAuth;
 pub use builder::BitgetBuilder;
+pub use endpoint_router::BitgetEndpointRouter;
 pub use error::{BitgetErrorCode, is_error_response, parse_error};
 pub use parser::{
     datetime_to_timestamp, parse_balance, parse_market, parse_ohlcv, parse_order,

--- a/ccxt-exchanges/src/bybit/endpoint_router.rs
+++ b/ccxt-exchanges/src/bybit/endpoint_router.rs
@@ -1,0 +1,350 @@
+//! Bybit-specific endpoint router trait.
+//!
+//! This module provides the `BybitEndpointRouter` trait for routing API requests
+//! to the correct Bybit endpoints based on market category.
+//!
+//! # Bybit API Structure
+//!
+//! Bybit V5 API uses a unified REST domain with category-based WebSocket paths:
+//! - **REST**: `api.bybit.com` - Single unified REST endpoint
+//! - **WebSocket Public**: `stream.bybit.com/v5/public/{category}` - Category-specific paths
+//! - **WebSocket Private**: `stream.bybit.com/v5/private` - Single private endpoint
+//!
+//! # Categories
+//!
+//! Bybit uses the following categories:
+//! - `spot` - Spot trading
+//! - `linear` - USDT-margined perpetuals and futures
+//! - `inverse` - Coin-margined perpetuals and futures
+//! - `option` - Options trading
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use ccxt_exchanges::bybit::{Bybit, BybitEndpointRouter};
+//! use ccxt_core::ExchangeConfig;
+//!
+//! let bybit = Bybit::new(ExchangeConfig::default()).unwrap();
+//!
+//! // Get REST endpoint (unified for all categories)
+//! let rest_url = bybit.rest_endpoint();
+//! assert!(rest_url.contains("api.bybit.com"));
+//!
+//! // Get WebSocket endpoint for linear category
+//! let ws_url = bybit.ws_public_endpoint("linear");
+//! assert!(ws_url.contains("/v5/public/linear"));
+//!
+//! // Get private WebSocket endpoint
+//! let ws_private_url = bybit.ws_private_endpoint();
+//! assert!(ws_private_url.contains("/v5/private"));
+//! ```
+
+/// Bybit-specific endpoint router trait.
+///
+/// This trait defines methods for obtaining the correct API endpoints for Bybit.
+/// Unlike Binance which has multiple REST domains, Bybit uses a unified REST
+/// endpoint with category-based WebSocket paths.
+///
+/// # Implementation Notes
+///
+/// - REST API uses a single unified domain for all market types
+/// - WebSocket public endpoints are differentiated by category path suffix
+/// - WebSocket private endpoint is unified for all authenticated streams
+/// - Sandbox/testnet mode switches to testnet domains
+pub trait BybitEndpointRouter {
+    /// Returns the REST API endpoint.
+    ///
+    /// Bybit uses a unified REST domain for all market types. The category
+    /// is specified as a query parameter in API requests, not in the URL.
+    ///
+    /// # Returns
+    ///
+    /// The REST API base URL string.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::bybit::{Bybit, BybitEndpointRouter};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let bybit = Bybit::new(ExchangeConfig::default()).unwrap();
+    /// let url = bybit.rest_endpoint();
+    /// assert!(url.contains("api.bybit.com"));
+    /// ```
+    fn rest_endpoint(&self) -> &str;
+
+    /// Returns the public WebSocket endpoint for a specific category.
+    ///
+    /// Bybit V5 API uses different WebSocket paths for different categories:
+    /// - `spot`: `/v5/public/spot`
+    /// - `linear`: `/v5/public/linear`
+    /// - `inverse`: `/v5/public/inverse`
+    /// - `option`: `/v5/public/option`
+    ///
+    /// # Arguments
+    ///
+    /// * `category` - The market category ("spot", "linear", "inverse", "option")
+    ///
+    /// # Returns
+    ///
+    /// The complete WebSocket URL for the specified category.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::bybit::{Bybit, BybitEndpointRouter};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let bybit = Bybit::new(ExchangeConfig::default()).unwrap();
+    ///
+    /// // Get WebSocket URL for linear perpetuals
+    /// let ws_url = bybit.ws_public_endpoint("linear");
+    /// assert!(ws_url.contains("/v5/public/linear"));
+    ///
+    /// // Get WebSocket URL for spot trading
+    /// let ws_spot_url = bybit.ws_public_endpoint("spot");
+    /// assert!(ws_spot_url.contains("/v5/public/spot"));
+    /// ```
+    fn ws_public_endpoint(&self, category: &str) -> String;
+
+    /// Returns the private WebSocket endpoint.
+    ///
+    /// Bybit uses a single private WebSocket endpoint for all authenticated
+    /// streams regardless of market category.
+    ///
+    /// # Returns
+    ///
+    /// The private WebSocket URL string.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::bybit::{Bybit, BybitEndpointRouter};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let bybit = Bybit::new(ExchangeConfig::default()).unwrap();
+    /// let ws_private_url = bybit.ws_private_endpoint();
+    /// assert!(ws_private_url.contains("/v5/private"));
+    /// ```
+    fn ws_private_endpoint(&self) -> &str;
+}
+
+use super::Bybit;
+
+impl BybitEndpointRouter for Bybit {
+    fn rest_endpoint(&self) -> &str {
+        // Use the existing urls() method which already handles sandbox mode
+        // We need to return a reference, so we'll use a static approach
+        // based on sandbox mode
+        if self.is_sandbox() {
+            "https://api-testnet.bybit.com"
+        } else {
+            "https://api.bybit.com"
+        }
+    }
+
+    fn ws_public_endpoint(&self, category: &str) -> String {
+        let urls = self.urls();
+        urls.ws_public_for_category(category)
+    }
+
+    fn ws_private_endpoint(&self) -> &str {
+        // Similar to rest_endpoint, return static reference based on sandbox mode
+        if self.is_sandbox() {
+            "wss://stream-testnet.bybit.com/v5/private"
+        } else {
+            "wss://stream.bybit.com/v5/private"
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bybit::BybitOptions;
+    use ccxt_core::ExchangeConfig;
+    use ccxt_core::types::default_type::{DefaultSubType, DefaultType};
+
+    fn create_test_bybit() -> Bybit {
+        Bybit::new(ExchangeConfig::default()).unwrap()
+    }
+
+    fn create_sandbox_bybit() -> Bybit {
+        let config = ExchangeConfig {
+            sandbox: true,
+            ..Default::default()
+        };
+        Bybit::new(config).unwrap()
+    }
+
+    // ==================== REST Endpoint Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_production() {
+        let bybit = create_test_bybit();
+        let url = bybit.rest_endpoint();
+        assert!(url.contains("api.bybit.com"));
+        assert!(!url.contains("testnet"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_sandbox() {
+        let bybit = create_sandbox_bybit();
+        let url = bybit.rest_endpoint();
+        assert!(url.contains("api-testnet.bybit.com"));
+    }
+
+    // ==================== WebSocket Public Endpoint Tests ====================
+
+    #[test]
+    fn test_ws_public_endpoint_spot() {
+        let bybit = create_test_bybit();
+        let url = bybit.ws_public_endpoint("spot");
+        assert!(url.contains("stream.bybit.com"));
+        assert!(url.ends_with("/v5/public/spot"));
+    }
+
+    #[test]
+    fn test_ws_public_endpoint_linear() {
+        let bybit = create_test_bybit();
+        let url = bybit.ws_public_endpoint("linear");
+        assert!(url.contains("stream.bybit.com"));
+        assert!(url.ends_with("/v5/public/linear"));
+    }
+
+    #[test]
+    fn test_ws_public_endpoint_inverse() {
+        let bybit = create_test_bybit();
+        let url = bybit.ws_public_endpoint("inverse");
+        assert!(url.contains("stream.bybit.com"));
+        assert!(url.ends_with("/v5/public/inverse"));
+    }
+
+    #[test]
+    fn test_ws_public_endpoint_option() {
+        let bybit = create_test_bybit();
+        let url = bybit.ws_public_endpoint("option");
+        assert!(url.contains("stream.bybit.com"));
+        assert!(url.ends_with("/v5/public/option"));
+    }
+
+    #[test]
+    fn test_ws_public_endpoint_sandbox_spot() {
+        let bybit = create_sandbox_bybit();
+        let url = bybit.ws_public_endpoint("spot");
+        assert!(url.contains("stream-testnet.bybit.com"));
+        assert!(url.ends_with("/v5/public/spot"));
+    }
+
+    #[test]
+    fn test_ws_public_endpoint_sandbox_linear() {
+        let bybit = create_sandbox_bybit();
+        let url = bybit.ws_public_endpoint("linear");
+        assert!(url.contains("stream-testnet.bybit.com"));
+        assert!(url.ends_with("/v5/public/linear"));
+    }
+
+    // ==================== WebSocket Private Endpoint Tests ====================
+
+    #[test]
+    fn test_ws_private_endpoint_production() {
+        let bybit = create_test_bybit();
+        let url = bybit.ws_private_endpoint();
+        assert!(url.contains("stream.bybit.com"));
+        assert!(url.contains("/v5/private"));
+        assert!(!url.contains("testnet"));
+    }
+
+    #[test]
+    fn test_ws_private_endpoint_sandbox() {
+        let bybit = create_sandbox_bybit();
+        let url = bybit.ws_private_endpoint();
+        assert!(url.contains("stream-testnet.bybit.com"));
+        assert!(url.contains("/v5/private"));
+    }
+
+    // ==================== Category Path Construction Tests ====================
+
+    #[test]
+    fn test_ws_public_endpoint_path_format() {
+        let bybit = create_test_bybit();
+
+        // Verify all categories follow the /v5/public/{category} format
+        let categories = ["spot", "linear", "inverse", "option"];
+        for category in categories {
+            let url = bybit.ws_public_endpoint(category);
+            let expected_suffix = format!("/v5/public/{}", category);
+            assert!(
+                url.ends_with(&expected_suffix),
+                "URL {} should end with {}",
+                url,
+                expected_suffix
+            );
+        }
+    }
+
+    // ==================== Testnet Option Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_with_testnet_option() {
+        let config = ExchangeConfig::default();
+        let options = BybitOptions {
+            testnet: true,
+            ..Default::default()
+        };
+        let bybit = Bybit::new_with_options(config, options).unwrap();
+
+        let url = bybit.rest_endpoint();
+        assert!(url.contains("api-testnet.bybit.com"));
+    }
+
+    #[test]
+    fn test_ws_private_endpoint_with_testnet_option() {
+        let config = ExchangeConfig::default();
+        let options = BybitOptions {
+            testnet: true,
+            ..Default::default()
+        };
+        let bybit = Bybit::new_with_options(config, options).unwrap();
+
+        let url = bybit.ws_private_endpoint();
+        assert!(url.contains("stream-testnet.bybit.com"));
+    }
+
+    // ==================== Integration with Default Type Tests ====================
+
+    #[test]
+    fn test_ws_public_endpoint_with_linear_default_type() {
+        let config = ExchangeConfig::default();
+        let options = BybitOptions {
+            default_type: DefaultType::Swap,
+            default_sub_type: Some(DefaultSubType::Linear),
+            ..Default::default()
+        };
+        let bybit = Bybit::new_with_options(config, options).unwrap();
+
+        // Use the category() method to get the correct category
+        let category = bybit.category();
+        assert_eq!(category, "linear");
+
+        let url = bybit.ws_public_endpoint(category);
+        assert!(url.ends_with("/v5/public/linear"));
+    }
+
+    #[test]
+    fn test_ws_public_endpoint_with_inverse_default_type() {
+        let config = ExchangeConfig::default();
+        let options = BybitOptions {
+            default_type: DefaultType::Swap,
+            default_sub_type: Some(DefaultSubType::Inverse),
+            ..Default::default()
+        };
+        let bybit = Bybit::new_with_options(config, options).unwrap();
+
+        let category = bybit.category();
+        assert_eq!(category, "inverse");
+
+        let url = bybit.ws_public_endpoint(category);
+        assert!(url.ends_with("/v5/public/inverse"));
+    }
+}

--- a/ccxt-exchanges/src/bybit/mod.rs
+++ b/ccxt-exchanges/src/bybit/mod.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 
 pub mod auth;
 pub mod builder;
+pub mod endpoint_router;
 pub mod error;
 pub mod parser;
 pub mod rest;
@@ -19,6 +20,7 @@ mod ws_exchange_impl;
 
 pub use auth::BybitAuth;
 pub use builder::BybitBuilder;
+pub use endpoint_router::BybitEndpointRouter;
 pub use error::{BybitErrorCode, is_error_response, parse_error};
 
 /// Bybit exchange structure.

--- a/ccxt-exchanges/src/hyperliquid/endpoint_router.rs
+++ b/ccxt-exchanges/src/hyperliquid/endpoint_router.rs
@@ -1,0 +1,286 @@
+//! HyperLiquid-specific endpoint router trait.
+//!
+//! This module provides the `HyperLiquidEndpointRouter` trait for routing API requests
+//! to the correct HyperLiquid endpoints.
+//!
+//! # HyperLiquid API Structure
+//!
+//! HyperLiquid uses the simplest endpoint structure among all supported exchanges:
+//! - **REST**: `api.hyperliquid.xyz` - Single REST endpoint for all operations
+//! - **WebSocket**: `api.hyperliquid.xyz/ws` - Single WebSocket endpoint
+//!
+//! Unlike centralized exchanges, HyperLiquid is a decentralized perpetual futures
+//! exchange built on its own L1 blockchain. It uses:
+//! - Ethereum wallet private keys for authentication (EIP-712 typed data signatures)
+//! - Wallet addresses as account identifiers (no registration required)
+//! - USDC as the sole settlement currency
+//!
+//! # Testnet/Sandbox Mode
+//!
+//! HyperLiquid provides a separate testnet environment:
+//! - REST: `api.hyperliquid-testnet.xyz`
+//! - WebSocket: `api.hyperliquid-testnet.xyz/ws`
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use ccxt_exchanges::hyperliquid::{HyperLiquid, HyperLiquidEndpointRouter};
+//!
+//! let exchange = HyperLiquid::builder()
+//!     .testnet(false)
+//!     .build()
+//!     .unwrap();
+//!
+//! // Get REST endpoint
+//! let rest_url = exchange.rest_endpoint();
+//! assert!(rest_url.contains("api.hyperliquid.xyz"));
+//!
+//! // Get WebSocket endpoint
+//! let ws_url = exchange.ws_endpoint();
+//! assert!(ws_url.contains("api.hyperliquid.xyz/ws"));
+//! ```
+
+/// HyperLiquid-specific endpoint router trait.
+///
+/// This trait defines methods for obtaining the correct API endpoints for HyperLiquid.
+/// HyperLiquid uses the simplest structure with a single REST and WebSocket endpoint.
+///
+/// # Implementation Notes
+///
+/// - REST API uses a single domain for all operations (`/info` for public, `/exchange` for private)
+/// - WebSocket has a single endpoint for all data streams
+/// - Authentication is handled via EIP-712 signatures, not separate endpoints
+/// - Testnet mode switches to completely different domains
+///
+/// # Sandbox/Testnet Mode
+///
+/// When sandbox mode is enabled (via `config.sandbox` or `options.testnet`):
+/// - REST URL changes to `api.hyperliquid-testnet.xyz`
+/// - WebSocket URL changes to `api.hyperliquid-testnet.xyz/ws`
+pub trait HyperLiquidEndpointRouter {
+    /// Returns the REST API endpoint.
+    ///
+    /// HyperLiquid uses a single REST domain for all operations.
+    /// The operation type is specified in the API path:
+    /// - `/info` - Public data requests
+    /// - `/exchange` - Private/authenticated requests
+    ///
+    /// # Returns
+    ///
+    /// The REST API base URL string.
+    ///
+    /// # Production vs Testnet
+    ///
+    /// - Production: `https://api.hyperliquid.xyz`
+    /// - Testnet: `https://api.hyperliquid-testnet.xyz`
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::hyperliquid::{HyperLiquid, HyperLiquidEndpointRouter};
+    ///
+    /// let exchange = HyperLiquid::builder().build().unwrap();
+    /// let url = exchange.rest_endpoint();
+    /// assert_eq!(url, "https://api.hyperliquid.xyz");
+    /// ```
+    fn rest_endpoint(&self) -> &str;
+
+    /// Returns the WebSocket endpoint.
+    ///
+    /// HyperLiquid uses a single WebSocket endpoint for all data streams.
+    /// Unlike other exchanges, there is no separation between public and private
+    /// WebSocket connections - authentication is handled at the message level.
+    ///
+    /// # Returns
+    ///
+    /// The complete WebSocket URL.
+    ///
+    /// # Production vs Testnet
+    ///
+    /// - Production: `wss://api.hyperliquid.xyz/ws`
+    /// - Testnet: `wss://api.hyperliquid-testnet.xyz/ws`
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::hyperliquid::{HyperLiquid, HyperLiquidEndpointRouter};
+    ///
+    /// let exchange = HyperLiquid::builder().build().unwrap();
+    /// let url = exchange.ws_endpoint();
+    /// assert_eq!(url, "wss://api.hyperliquid.xyz/ws");
+    /// ```
+    fn ws_endpoint(&self) -> &str;
+}
+
+use super::HyperLiquid;
+
+impl HyperLiquidEndpointRouter for HyperLiquid {
+    fn rest_endpoint(&self) -> &str {
+        // Return static reference based on sandbox mode
+        // is_sandbox() checks both config.sandbox and options.testnet
+        if self.is_sandbox() {
+            "https://api.hyperliquid-testnet.xyz"
+        } else {
+            "https://api.hyperliquid.xyz"
+        }
+    }
+
+    fn ws_endpoint(&self) -> &str {
+        // Return static reference based on sandbox mode
+        // is_sandbox() checks both config.sandbox and options.testnet
+        if self.is_sandbox() {
+            "wss://api.hyperliquid-testnet.xyz/ws"
+        } else {
+            "wss://api.hyperliquid.xyz/ws"
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hyperliquid::HyperLiquidOptions;
+    use ccxt_core::ExchangeConfig;
+
+    fn create_test_hyperliquid() -> HyperLiquid {
+        HyperLiquid::builder().build().unwrap()
+    }
+
+    fn create_testnet_hyperliquid() -> HyperLiquid {
+        HyperLiquid::builder().testnet(true).build().unwrap()
+    }
+
+    fn create_sandbox_hyperliquid() -> HyperLiquid {
+        let config = ExchangeConfig {
+            sandbox: true,
+            ..Default::default()
+        };
+        let options = HyperLiquidOptions::default();
+        HyperLiquid::new_with_options(config, options, None).unwrap()
+    }
+
+    // ==================== REST Endpoint Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_production() {
+        let exchange = create_test_hyperliquid();
+        let url = exchange.rest_endpoint();
+        assert_eq!(url, "https://api.hyperliquid.xyz");
+        assert!(!url.contains("testnet"));
+    }
+
+    #[test]
+    fn test_rest_endpoint_testnet() {
+        let exchange = create_testnet_hyperliquid();
+        let url = exchange.rest_endpoint();
+        assert_eq!(url, "https://api.hyperliquid-testnet.xyz");
+    }
+
+    #[test]
+    fn test_rest_endpoint_sandbox() {
+        let exchange = create_sandbox_hyperliquid();
+        let url = exchange.rest_endpoint();
+        assert_eq!(url, "https://api.hyperliquid-testnet.xyz");
+    }
+
+    // ==================== WebSocket Endpoint Tests ====================
+
+    #[test]
+    fn test_ws_endpoint_production() {
+        let exchange = create_test_hyperliquid();
+        let url = exchange.ws_endpoint();
+        assert_eq!(url, "wss://api.hyperliquid.xyz/ws");
+        assert!(!url.contains("testnet"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_testnet() {
+        let exchange = create_testnet_hyperliquid();
+        let url = exchange.ws_endpoint();
+        assert_eq!(url, "wss://api.hyperliquid-testnet.xyz/ws");
+    }
+
+    #[test]
+    fn test_ws_endpoint_sandbox() {
+        let exchange = create_sandbox_hyperliquid();
+        let url = exchange.ws_endpoint();
+        assert_eq!(url, "wss://api.hyperliquid-testnet.xyz/ws");
+    }
+
+    // ==================== Consistency Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_consistency_with_urls() {
+        let exchange = create_test_hyperliquid();
+        let router_url = exchange.rest_endpoint();
+        let urls_rest = &exchange.urls().rest;
+        assert_eq!(router_url, urls_rest);
+    }
+
+    #[test]
+    fn test_ws_endpoint_consistency_with_urls() {
+        let exchange = create_test_hyperliquid();
+        let router_url = exchange.ws_endpoint();
+        let urls_ws = &exchange.urls().ws;
+        assert_eq!(router_url, urls_ws);
+    }
+
+    #[test]
+    fn test_testnet_rest_endpoint_consistency_with_urls() {
+        let exchange = create_testnet_hyperliquid();
+        let router_url = exchange.rest_endpoint();
+        let urls_rest = &exchange.urls().rest;
+        assert_eq!(router_url, urls_rest);
+    }
+
+    #[test]
+    fn test_testnet_ws_endpoint_consistency_with_urls() {
+        let exchange = create_testnet_hyperliquid();
+        let router_url = exchange.ws_endpoint();
+        let urls_ws = &exchange.urls().ws;
+        assert_eq!(router_url, urls_ws);
+    }
+
+    // ==================== URL Format Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_uses_https() {
+        let exchange = create_test_hyperliquid();
+        let url = exchange.rest_endpoint();
+        assert!(url.starts_with("https://"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_uses_wss() {
+        let exchange = create_test_hyperliquid();
+        let url = exchange.ws_endpoint();
+        assert!(url.starts_with("wss://"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_contains_ws_path() {
+        let exchange = create_test_hyperliquid();
+        let url = exchange.ws_endpoint();
+        assert!(url.ends_with("/ws"));
+    }
+
+    // ==================== Sandbox Mode Tests ====================
+
+    #[test]
+    fn test_is_sandbox_with_testnet_option() {
+        let exchange = create_testnet_hyperliquid();
+        assert!(exchange.is_sandbox());
+    }
+
+    #[test]
+    fn test_is_sandbox_with_config_sandbox() {
+        let exchange = create_sandbox_hyperliquid();
+        assert!(exchange.is_sandbox());
+    }
+
+    #[test]
+    fn test_is_not_sandbox_by_default() {
+        let exchange = create_test_hyperliquid();
+        assert!(!exchange.is_sandbox());
+    }
+}

--- a/ccxt-exchanges/src/hyperliquid/mod.rs
+++ b/ccxt-exchanges/src/hyperliquid/mod.rs
@@ -50,6 +50,7 @@ use ccxt_core::{BaseExchange, ExchangeConfig, Result};
 
 pub mod auth;
 pub mod builder;
+pub mod endpoint_router;
 pub mod error;
 mod exchange_impl;
 pub mod parser;
@@ -59,6 +60,7 @@ mod ws_exchange_impl;
 
 pub use auth::HyperLiquidAuth;
 pub use builder::{HyperLiquidBuilder, validate_default_type};
+pub use endpoint_router::HyperLiquidEndpointRouter;
 pub use error::{HyperLiquidErrorCode, is_error_response, parse_error};
 
 /// HyperLiquid exchange structure.

--- a/ccxt-exchanges/src/okx/endpoint_router.rs
+++ b/ccxt-exchanges/src/okx/endpoint_router.rs
@@ -1,0 +1,477 @@
+//! OKX-specific endpoint router trait.
+//!
+//! This module provides the `OkxEndpointRouter` trait for routing API requests
+//! to the correct OKX endpoints based on channel type.
+//!
+//! # OKX API Structure
+//!
+//! OKX uses a unified V5 API with the following endpoint structure:
+//! - **REST**: `www.okx.com` - Single unified REST endpoint for all market types
+//! - **WebSocket Public**: `ws.okx.com:8443/ws/v5/public` - Public market data
+//! - **WebSocket Private**: `ws.okx.com:8443/ws/v5/private` - Account data
+//! - **WebSocket Business**: `ws.okx.com:8443/ws/v5/business` - Trade execution
+//!
+//! # Demo Trading Mode
+//!
+//! OKX uses a unique approach for demo trading:
+//! - REST API uses the **same production domain** (`www.okx.com`)
+//! - Demo mode is indicated by the `x-simulated-trading: 1` header
+//! - WebSocket URLs switch to demo domain (`wspap.okx.com:8443`)
+//!
+//! # Channel Types
+//!
+//! OKX WebSocket has three channel types:
+//! - `Public` - Market data (tickers, orderbooks, trades)
+//! - `Private` - Account data (positions, orders, balances)
+//! - `Business` - Trade execution and advanced features
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use ccxt_exchanges::okx::{Okx, OkxEndpointRouter, OkxChannelType};
+//! use ccxt_core::ExchangeConfig;
+//!
+//! let okx = Okx::new(ExchangeConfig::default()).unwrap();
+//!
+//! // Get REST endpoint (unified for all market types)
+//! let rest_url = okx.rest_endpoint();
+//! assert!(rest_url.contains("okx.com"));
+//!
+//! // Get WebSocket endpoint for public channel
+//! let ws_public = okx.ws_endpoint(OkxChannelType::Public);
+//! assert!(ws_public.contains("/ws/v5/public"));
+//!
+//! // Get WebSocket endpoint for private channel
+//! let ws_private = okx.ws_endpoint(OkxChannelType::Private);
+//! assert!(ws_private.contains("/ws/v5/private"));
+//!
+//! // Check if demo trading mode is enabled
+//! let is_demo = okx.is_demo_trading();
+//! ```
+
+/// OKX WebSocket channel type.
+///
+/// OKX uses different WebSocket channels for different types of data:
+/// - `Public` - Market data streams (no authentication required)
+/// - `Private` - Account data streams (authentication required)
+/// - `Business` - Trade execution streams (authentication required)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OkxChannelType {
+    /// Public channel for market data (tickers, orderbooks, trades).
+    ///
+    /// No authentication required. Used for:
+    /// - Real-time ticker updates
+    /// - Order book snapshots and updates
+    /// - Public trade streams
+    /// - Candlestick/OHLCV data
+    Public,
+
+    /// Private channel for account data.
+    ///
+    /// Authentication required. Used for:
+    /// - Account balance updates
+    /// - Position updates
+    /// - Order status updates
+    Private,
+
+    /// Business channel for trade execution.
+    ///
+    /// Authentication required. Used for:
+    /// - Advanced order types
+    /// - Algo orders
+    /// - Grid trading
+    /// - Copy trading
+    Business,
+}
+
+impl std::fmt::Display for OkxChannelType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OkxChannelType::Public => write!(f, "public"),
+            OkxChannelType::Private => write!(f, "private"),
+            OkxChannelType::Business => write!(f, "business"),
+        }
+    }
+}
+
+/// OKX-specific endpoint router trait.
+///
+/// This trait defines methods for obtaining the correct API endpoints for OKX.
+/// OKX uses a unified REST endpoint for all market types, with WebSocket
+/// channels differentiated by channel type (public, private, business).
+///
+/// # Implementation Notes
+///
+/// - REST API uses a single unified domain for all market types
+/// - Demo trading mode uses the same REST domain but adds a special header
+/// - WebSocket endpoints are differentiated by channel type
+/// - Demo mode WebSocket URLs use a different domain (`wspap.okx.com`)
+///
+/// # Demo Trading
+///
+/// OKX's demo trading mode is unique:
+/// - REST requests use the production domain with `x-simulated-trading: 1` header
+/// - WebSocket connections use demo-specific URLs with `brokerId=9999` parameter
+pub trait OkxEndpointRouter {
+    /// Returns the REST API endpoint.
+    ///
+    /// OKX uses a unified REST domain for all market types. The instrument
+    /// type is specified as a query parameter in API requests, not in the URL.
+    ///
+    /// Note: For demo trading, the same URL is used but with the
+    /// `x-simulated-trading: 1` header added to requests.
+    ///
+    /// # Returns
+    ///
+    /// The REST API base URL string.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::okx::{Okx, OkxEndpointRouter};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let okx = Okx::new(ExchangeConfig::default()).unwrap();
+    /// let url = okx.rest_endpoint();
+    /// assert_eq!(url, "https://www.okx.com");
+    /// ```
+    fn rest_endpoint(&self) -> &str;
+
+    /// Returns the WebSocket endpoint for a specific channel type.
+    ///
+    /// OKX uses different WebSocket URLs for different channel types:
+    /// - `Public`: `/ws/v5/public` - Market data
+    /// - `Private`: `/ws/v5/private` - Account data
+    /// - `Business`: `/ws/v5/business` - Trade execution
+    ///
+    /// In demo trading mode, the URLs switch to the demo domain
+    /// (`wspap.okx.com`) with `brokerId=9999` parameter.
+    ///
+    /// # Arguments
+    ///
+    /// * `channel_type` - The WebSocket channel type (Public, Private, Business)
+    ///
+    /// # Returns
+    ///
+    /// The complete WebSocket URL for the specified channel type.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::okx::{Okx, OkxEndpointRouter, OkxChannelType};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// let okx = Okx::new(ExchangeConfig::default()).unwrap();
+    ///
+    /// // Get WebSocket URL for public market data
+    /// let ws_public = okx.ws_endpoint(OkxChannelType::Public);
+    /// assert!(ws_public.contains("/ws/v5/public"));
+    ///
+    /// // Get WebSocket URL for private account data
+    /// let ws_private = okx.ws_endpoint(OkxChannelType::Private);
+    /// assert!(ws_private.contains("/ws/v5/private"));
+    ///
+    /// // Get WebSocket URL for business/trading
+    /// let ws_business = okx.ws_endpoint(OkxChannelType::Business);
+    /// assert!(ws_business.contains("/ws/v5/business"));
+    /// ```
+    fn ws_endpoint(&self, channel_type: OkxChannelType) -> &str;
+
+    /// Returns whether demo trading mode is enabled.
+    ///
+    /// Demo trading mode is enabled when either:
+    /// - `config.sandbox` is set to `true`
+    /// - `options.testnet` is set to `true`
+    ///
+    /// When demo trading is enabled:
+    /// - REST requests should include the `x-simulated-trading: 1` header
+    /// - WebSocket URLs use the demo domain (`wspap.okx.com`)
+    ///
+    /// # Returns
+    ///
+    /// `true` if demo trading mode is enabled, `false` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ccxt_exchanges::okx::{Okx, OkxEndpointRouter};
+    /// use ccxt_core::ExchangeConfig;
+    ///
+    /// // Production mode
+    /// let okx = Okx::new(ExchangeConfig::default()).unwrap();
+    /// assert!(!okx.is_demo_trading());
+    ///
+    /// // Demo mode
+    /// let config = ExchangeConfig {
+    ///     sandbox: true,
+    ///     ..Default::default()
+    /// };
+    /// let okx_demo = Okx::new(config).unwrap();
+    /// assert!(okx_demo.is_demo_trading());
+    /// ```
+    fn is_demo_trading(&self) -> bool;
+}
+
+use super::Okx;
+
+impl OkxEndpointRouter for Okx {
+    fn rest_endpoint(&self) -> &str {
+        // OKX uses the same REST domain for both production and demo trading.
+        // Demo mode is indicated by the `x-simulated-trading: 1` header,
+        // not by a different URL.
+        "https://www.okx.com"
+    }
+
+    fn ws_endpoint(&self, channel_type: OkxChannelType) -> &str {
+        // OKX WebSocket URLs differ between production and demo mode
+        if self.is_testnet_trading() {
+            // Demo trading WebSocket URLs
+            match channel_type {
+                OkxChannelType::Public => "wss://wspap.okx.com:8443/ws/v5/public?brokerId=9999",
+                OkxChannelType::Private => "wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999",
+                OkxChannelType::Business => "wss://wspap.okx.com:8443/ws/v5/business?brokerId=9999",
+            }
+        } else {
+            // Production WebSocket URLs
+            match channel_type {
+                OkxChannelType::Public => "wss://ws.okx.com:8443/ws/v5/public",
+                OkxChannelType::Private => "wss://ws.okx.com:8443/ws/v5/private",
+                OkxChannelType::Business => "wss://ws.okx.com:8443/ws/v5/business",
+            }
+        }
+    }
+
+    fn is_demo_trading(&self) -> bool {
+        // Delegate to the existing method that checks both config.sandbox and options.testnet
+        self.is_testnet_trading()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::okx::OkxOptions;
+    use ccxt_core::ExchangeConfig;
+
+    fn create_test_okx() -> Okx {
+        Okx::new(ExchangeConfig::default()).unwrap()
+    }
+
+    fn create_demo_okx() -> Okx {
+        let config = ExchangeConfig {
+            sandbox: true,
+            ..Default::default()
+        };
+        Okx::new(config).unwrap()
+    }
+
+    // ==================== REST Endpoint Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_production() {
+        let okx = create_test_okx();
+        let url = okx.rest_endpoint();
+        assert_eq!(url, "https://www.okx.com");
+    }
+
+    #[test]
+    fn test_rest_endpoint_demo() {
+        let okx = create_demo_okx();
+        let url = okx.rest_endpoint();
+        // OKX uses the same REST domain for demo trading
+        // Demo mode is indicated by header, not URL
+        assert_eq!(url, "https://www.okx.com");
+    }
+
+    // ==================== WebSocket Public Endpoint Tests ====================
+
+    #[test]
+    fn test_ws_endpoint_public_production() {
+        let okx = create_test_okx();
+        let url = okx.ws_endpoint(OkxChannelType::Public);
+        assert_eq!(url, "wss://ws.okx.com:8443/ws/v5/public");
+        assert!(!url.contains("brokerId"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_public_demo() {
+        let okx = create_demo_okx();
+        let url = okx.ws_endpoint(OkxChannelType::Public);
+        assert!(url.contains("wspap.okx.com"));
+        assert!(url.contains("/ws/v5/public"));
+        assert!(url.contains("brokerId=9999"));
+    }
+
+    // ==================== WebSocket Private Endpoint Tests ====================
+
+    #[test]
+    fn test_ws_endpoint_private_production() {
+        let okx = create_test_okx();
+        let url = okx.ws_endpoint(OkxChannelType::Private);
+        assert_eq!(url, "wss://ws.okx.com:8443/ws/v5/private");
+        assert!(!url.contains("brokerId"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_private_demo() {
+        let okx = create_demo_okx();
+        let url = okx.ws_endpoint(OkxChannelType::Private);
+        assert!(url.contains("wspap.okx.com"));
+        assert!(url.contains("/ws/v5/private"));
+        assert!(url.contains("brokerId=9999"));
+    }
+
+    // ==================== WebSocket Business Endpoint Tests ====================
+
+    #[test]
+    fn test_ws_endpoint_business_production() {
+        let okx = create_test_okx();
+        let url = okx.ws_endpoint(OkxChannelType::Business);
+        assert_eq!(url, "wss://ws.okx.com:8443/ws/v5/business");
+        assert!(!url.contains("brokerId"));
+    }
+
+    #[test]
+    fn test_ws_endpoint_business_demo() {
+        let okx = create_demo_okx();
+        let url = okx.ws_endpoint(OkxChannelType::Business);
+        assert!(url.contains("wspap.okx.com"));
+        assert!(url.contains("/ws/v5/business"));
+        assert!(url.contains("brokerId=9999"));
+    }
+
+    // ==================== Demo Trading Mode Tests ====================
+
+    #[test]
+    fn test_is_demo_trading_false_by_default() {
+        let okx = create_test_okx();
+        assert!(!okx.is_demo_trading());
+    }
+
+    #[test]
+    fn test_is_demo_trading_with_sandbox_config() {
+        let okx = create_demo_okx();
+        assert!(okx.is_demo_trading());
+    }
+
+    #[test]
+    fn test_is_demo_trading_with_testnet_option() {
+        let config = ExchangeConfig::default();
+        let options = OkxOptions {
+            testnet: true,
+            ..Default::default()
+        };
+        let okx = Okx::new_with_options(config, options).unwrap();
+        assert!(okx.is_demo_trading());
+    }
+
+    // ==================== Channel Type Display Tests ====================
+
+    #[test]
+    fn test_channel_type_display() {
+        assert_eq!(format!("{}", OkxChannelType::Public), "public");
+        assert_eq!(format!("{}", OkxChannelType::Private), "private");
+        assert_eq!(format!("{}", OkxChannelType::Business), "business");
+    }
+
+    // ==================== Channel Type Equality Tests ====================
+
+    #[test]
+    fn test_channel_type_equality() {
+        assert_eq!(OkxChannelType::Public, OkxChannelType::Public);
+        assert_eq!(OkxChannelType::Private, OkxChannelType::Private);
+        assert_eq!(OkxChannelType::Business, OkxChannelType::Business);
+        assert_ne!(OkxChannelType::Public, OkxChannelType::Private);
+        assert_ne!(OkxChannelType::Private, OkxChannelType::Business);
+    }
+
+    // ==================== All Channel Types Tests ====================
+
+    #[test]
+    fn test_all_channel_types_production() {
+        let okx = create_test_okx();
+
+        let channels = [
+            (OkxChannelType::Public, "/ws/v5/public"),
+            (OkxChannelType::Private, "/ws/v5/private"),
+            (OkxChannelType::Business, "/ws/v5/business"),
+        ];
+
+        for (channel_type, expected_path) in channels {
+            let url = okx.ws_endpoint(channel_type);
+            assert!(
+                url.contains(expected_path),
+                "URL {} should contain {}",
+                url,
+                expected_path
+            );
+            assert!(
+                url.contains("ws.okx.com"),
+                "Production URL {} should contain ws.okx.com",
+                url
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_channel_types_demo() {
+        let okx = create_demo_okx();
+
+        let channels = [
+            (OkxChannelType::Public, "/ws/v5/public"),
+            (OkxChannelType::Private, "/ws/v5/private"),
+            (OkxChannelType::Business, "/ws/v5/business"),
+        ];
+
+        for (channel_type, expected_path) in channels {
+            let url = okx.ws_endpoint(channel_type);
+            assert!(
+                url.contains(expected_path),
+                "URL {} should contain {}",
+                url,
+                expected_path
+            );
+            assert!(
+                url.contains("wspap.okx.com"),
+                "Demo URL {} should contain wspap.okx.com",
+                url
+            );
+            assert!(
+                url.contains("brokerId=9999"),
+                "Demo URL {} should contain brokerId=9999",
+                url
+            );
+        }
+    }
+
+    // ==================== Consistency Tests ====================
+
+    #[test]
+    fn test_rest_endpoint_same_for_production_and_demo() {
+        let okx_prod = create_test_okx();
+        let okx_demo = create_demo_okx();
+
+        // OKX uses the same REST domain for both modes
+        assert_eq!(okx_prod.rest_endpoint(), okx_demo.rest_endpoint());
+    }
+
+    #[test]
+    fn test_ws_endpoints_differ_for_production_and_demo() {
+        let okx_prod = create_test_okx();
+        let okx_demo = create_demo_okx();
+
+        // WebSocket URLs should be different
+        assert_ne!(
+            okx_prod.ws_endpoint(OkxChannelType::Public),
+            okx_demo.ws_endpoint(OkxChannelType::Public)
+        );
+        assert_ne!(
+            okx_prod.ws_endpoint(OkxChannelType::Private),
+            okx_demo.ws_endpoint(OkxChannelType::Private)
+        );
+        assert_ne!(
+            okx_prod.ws_endpoint(OkxChannelType::Business),
+            okx_demo.ws_endpoint(OkxChannelType::Business)
+        );
+    }
+}

--- a/ccxt-exchanges/src/okx/mod.rs
+++ b/ccxt-exchanges/src/okx/mod.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 
 pub mod auth;
 pub mod builder;
+pub mod endpoint_router;
 pub mod error;
 pub mod exchange_impl;
 pub mod parser;
@@ -20,6 +21,7 @@ pub mod ws_exchange_impl;
 
 pub use auth::OkxAuth;
 pub use builder::OkxBuilder;
+pub use endpoint_router::{OkxChannelType, OkxEndpointRouter};
 pub use error::{OkxErrorCode, is_error_response, parse_error};
 
 /// OKX exchange structure.


### PR DESCRIPTION
- Introduce EndpointType enum to distinguish public/private API endpoints
- Add endpoint module with comprehensive test coverage for endpoint types
- Implement BinanceEndpointRouter trait with market-specific routing logic
- Add Bitget, Bybit, HyperLiquid and Okx endpoint router modules
- Update exchange modules to use centralized endpoint routing
- Add .specify/ to .gitignore for specification files
- Refactor Binance to delegate endpoint selection to router implementation