### PR TITLE
refactor(exchange): update order creation methods to use type-safe Am…

### DIFF
--- a/ccxt-core/src/exchange.rs
+++ b/ccxt-core/src/exchange.rs
@@ -187,11 +187,11 @@
 //! - [`crate::base_exchange::BaseExchange`]: Base implementation utilities
 
 use async_trait::async_trait;
-use rust_decimal::Decimal;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::error::Result;
+use crate::types::financial::{Amount, Price};
 use crate::types::*;
 
 // Re-export ExchangeCapabilities and related types from the capability module
@@ -406,8 +406,8 @@ pub trait Exchange: Send + Sync {
     /// * `symbol` - Trading pair symbol
     /// * `order_type` - Order type (limit, market, etc.)
     /// * `side` - Order side (buy or sell)
-    /// * `amount` - Order amount
-    /// * `price` - Optional price (required for limit orders)
+    /// * `amount` - Order amount (type-safe Amount wrapper)
+    /// * `price` - Optional price (required for limit orders, type-safe Price wrapper)
     ///
     /// # Returns
     ///
@@ -421,8 +421,8 @@ pub trait Exchange: Send + Sync {
         symbol: &str,
         order_type: OrderType,
         side: OrderSide,
-        amount: Decimal,
-        price: Option<Decimal>,
+        amount: Amount,
+        price: Option<Price>,
     ) -> Result<Order>;
 
     /// Cancel an existing order

--- a/ccxt-exchanges/src/binance/exchange_impl.rs
+++ b/ccxt-exchanges/src/binance/exchange_impl.rs
@@ -25,11 +25,11 @@ use ccxt_core::{
     exchange::{Capability, Exchange, ExchangeCapabilities},
     traits::PublicExchange,
     types::{
-        Balance, Market, Ohlcv, Order, OrderBook, OrderSide, OrderType, Ticker, Timeframe, Trade,
+        Amount, Balance, Market, Ohlcv, Order, OrderBook, OrderSide, OrderType, Price, Ticker,
+        Timeframe, Trade,
     },
 };
 use rust_decimal::Decimal;
-use rust_decimal::prelude::ToPrimitive;
 use std::collections::HashMap;
 
 use super::Binance;
@@ -169,21 +169,11 @@ impl Exchange for Binance {
         symbol: &str,
         order_type: OrderType,
         side: OrderSide,
-        amount: Decimal,
-        price: Option<Decimal>,
+        amount: Amount,
+        price: Option<Price>,
     ) -> Result<Order> {
-        // Convert Decimal to f64 for existing implementation
-        let amount_f64 = amount
-            .to_f64()
-            .ok_or_else(|| ccxt_core::Error::invalid_request("Failed to convert amount to f64"))?;
-        let price_f64 = match price {
-            Some(p) => Some(p.to_f64().ok_or_else(|| {
-                ccxt_core::Error::invalid_request("Failed to convert price to f64")
-            })?),
-            None => None,
-        };
-
-        Binance::create_order(self, symbol, order_type, side, amount_f64, price_f64, None).await
+        // Direct delegation - no type conversion needed
+        Binance::create_order(self, symbol, order_type, side, amount, price, None).await
     }
 
     async fn cancel_order(&self, id: &str, symbol: Option<&str>) -> Result<Order> {

--- a/ccxt-exchanges/src/bitget/exchange_impl.rs
+++ b/ccxt-exchanges/src/bitget/exchange_impl.rs
@@ -12,7 +12,6 @@ use ccxt_core::{
     },
 };
 use rust_decimal::Decimal;
-use rust_decimal::prelude::ToPrimitive;
 use std::collections::HashMap;
 
 use super::Bitget;
@@ -157,20 +156,11 @@ impl Exchange for Bitget {
         symbol: &str,
         order_type: OrderType,
         side: OrderSide,
-        amount: Decimal,
-        price: Option<Decimal>,
+        amount: Amount,
+        price: Option<Price>,
     ) -> Result<Order> {
-        let amount_f64 = amount
-            .to_f64()
-            .ok_or_else(|| ccxt_core::Error::invalid_request("Failed to convert amount to f64"))?;
-        let price_f64 = match price {
-            Some(p) => Some(p.to_f64().ok_or_else(|| {
-                ccxt_core::Error::invalid_request("Failed to convert price to f64")
-            })?),
-            None => None,
-        };
-
-        Bitget::create_order(self, symbol, order_type, side, amount_f64, price_f64).await
+        // Direct delegation - no type conversion needed
+        Bitget::create_order(self, symbol, order_type, side, amount, price).await
     }
 
     async fn cancel_order(&self, id: &str, symbol: Option<&str>) -> Result<Order> {

--- a/ccxt-exchanges/src/bitget/rest.rs
+++ b/ccxt-exchanges/src/bitget/rest.rs
@@ -5,7 +5,10 @@
 use super::{Bitget, BitgetAuth, error, parser};
 use ccxt_core::{
     Error, ParseError, Result,
-    types::{Balance, Market, OHLCV, Order, OrderBook, OrderSide, OrderType, Ticker, Trade},
+    types::{
+        Amount, Balance, Market, OHLCV, Order, OrderBook, OrderSide, OrderType, Price, Ticker,
+        Trade,
+    },
 };
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
@@ -800,8 +803,8 @@ impl Bitget {
     /// * `symbol` - Trading pair symbol.
     /// * `order_type` - Order type (Market, Limit).
     /// * `side` - Order side (Buy or Sell).
-    /// * `amount` - Order quantity.
-    /// * `price` - Optional price (required for limit orders).
+    /// * `amount` - Order quantity as [`Amount`] type.
+    /// * `price` - Optional price as [`Price`] type (required for limit orders).
     ///
     /// # Returns
     ///
@@ -815,7 +818,8 @@ impl Bitget {
     ///
     /// ```no_run
     /// # use ccxt_exchanges::bitget::Bitget;
-    /// # use ccxt_core::types::{OrderType, OrderSide};
+    /// # use ccxt_core::types::{OrderType, OrderSide, Amount, Price};
+    /// # use rust_decimal_macros::dec;
     /// # async fn example() -> ccxt_core::Result<()> {
     /// let bitget = Bitget::builder()
     ///     .api_key("your-api-key")
@@ -829,8 +833,8 @@ impl Bitget {
     ///     "BTC/USDT",
     ///     OrderType::Limit,
     ///     OrderSide::Buy,
-    ///     0.001,
-    ///     Some(50000.0),
+    ///     Amount::new(dec!(0.001)),
+    ///     Some(Price::new(dec!(50000.0))),
     /// ).await?;
     /// println!("Order created: {}", order.id);
     /// # Ok(())
@@ -841,8 +845,8 @@ impl Bitget {
         symbol: &str,
         order_type: OrderType,
         side: OrderSide,
-        amount: f64,
-        price: Option<f64>,
+        amount: Amount,
+        price: Option<Price>,
     ) -> Result<Order> {
         let market = self.base().market(symbol).await?;
 

--- a/ccxt-exchanges/src/bybit/rest.rs
+++ b/ccxt-exchanges/src/bybit/rest.rs
@@ -5,7 +5,10 @@
 use super::{Bybit, BybitAuth, error, parser};
 use ccxt_core::{
     Error, ParseError, Result,
-    types::{Balance, Market, OHLCV, Order, OrderBook, OrderSide, OrderType, Ticker, Trade},
+    types::{
+        Amount, Balance, Market, OHLCV, Order, OrderBook, OrderSide, OrderType, Price, Ticker,
+        Trade,
+    },
 };
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
@@ -674,8 +677,8 @@ impl Bybit {
     /// * `symbol` - Trading pair symbol.
     /// * `order_type` - Order type (Market, Limit).
     /// * `side` - Order side (Buy or Sell).
-    /// * `amount` - Order quantity.
-    /// * `price` - Optional price (required for limit orders).
+    /// * `amount` - Order quantity as [`Amount`] type.
+    /// * `price` - Optional price as [`Price`] type (required for limit orders).
     ///
     /// # Returns
     ///
@@ -685,8 +688,8 @@ impl Bybit {
         symbol: &str,
         order_type: OrderType,
         side: OrderSide,
-        amount: f64,
-        price: Option<f64>,
+        amount: Amount,
+        price: Option<Price>,
     ) -> Result<Order> {
         let market = self.base().market(symbol).await?;
 

--- a/ccxt-exchanges/src/hyperliquid/exchange_impl.rs
+++ b/ccxt-exchanges/src/hyperliquid/exchange_impl.rs
@@ -7,11 +7,10 @@ use ccxt_core::{
     Result,
     exchange::{Capability, Exchange, ExchangeCapabilities},
     types::{
-        Balance, Market, Ohlcv, Order, OrderBook, OrderSide, OrderType, Ticker, Timeframe, Trade,
+        Amount, Balance, Market, Ohlcv, Order, OrderBook, OrderSide, OrderType, Price, Ticker,
+        Timeframe, Trade,
     },
 };
-use rust_decimal::Decimal;
-use rust_decimal::prelude::ToPrimitive;
 use std::collections::HashMap;
 
 use super::HyperLiquid;
@@ -142,20 +141,11 @@ impl Exchange for HyperLiquid {
         symbol: &str,
         order_type: OrderType,
         side: OrderSide,
-        amount: Decimal,
-        price: Option<Decimal>,
+        amount: Amount,
+        price: Option<Price>,
     ) -> Result<Order> {
-        let amount_f64 = amount
-            .to_f64()
-            .ok_or_else(|| ccxt_core::Error::invalid_request("Failed to convert amount to f64"))?;
-        let price_f64 = match price {
-            Some(p) => Some(p.to_f64().ok_or_else(|| {
-                ccxt_core::Error::invalid_request("Failed to convert price to f64")
-            })?),
-            None => None,
-        };
-
-        HyperLiquid::create_order(self, symbol, order_type, side, amount_f64, price_f64).await
+        // Direct delegation - no type conversion needed
+        HyperLiquid::create_order(self, symbol, order_type, side, amount, price).await
     }
 
     async fn cancel_order(&self, id: &str, symbol: Option<&str>) -> Result<Order> {

--- a/ccxt-exchanges/src/okx/exchange_impl.rs
+++ b/ccxt-exchanges/src/okx/exchange_impl.rs
@@ -12,7 +12,6 @@ use ccxt_core::{
     },
 };
 use rust_decimal::Decimal;
-use rust_decimal::prelude::ToPrimitive;
 use std::collections::HashMap;
 
 use super::Okx;
@@ -151,20 +150,11 @@ impl Exchange for Okx {
         symbol: &str,
         order_type: OrderType,
         side: OrderSide,
-        amount: Decimal,
-        price: Option<Decimal>,
+        amount: Amount,
+        price: Option<Price>,
     ) -> Result<Order> {
-        let amount_f64 = amount
-            .to_f64()
-            .ok_or_else(|| ccxt_core::Error::invalid_request("Failed to convert amount to f64"))?;
-        let price_f64 = match price {
-            Some(p) => Some(p.to_f64().ok_or_else(|| {
-                ccxt_core::Error::invalid_request("Failed to convert price to f64")
-            })?),
-            None => None,
-        };
-
-        Okx::create_order(self, symbol, order_type, side, amount_f64, price_f64).await
+        // Direct delegation - no type conversion needed
+        Okx::create_order(self, symbol, order_type, side, amount, price).await
     }
 
     async fn cancel_order(&self, id: &str, symbol: Option<&str>) -> Result<Order> {

--- a/ccxt-exchanges/src/okx/rest.rs
+++ b/ccxt-exchanges/src/okx/rest.rs
@@ -5,7 +5,10 @@
 use super::{Okx, OkxAuth, error, parser};
 use ccxt_core::{
     Error, ParseError, Result,
-    types::{Balance, Market, OHLCV, Order, OrderBook, OrderSide, OrderType, Ticker, Trade},
+    types::{
+        Amount, Balance, Market, OHLCV, Order, OrderBook, OrderSide, OrderType, Price, Ticker,
+        Trade,
+    },
 };
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
@@ -733,8 +736,8 @@ impl Okx {
         symbol: &str,
         order_type: OrderType,
         side: OrderSide,
-        amount: f64,
-        price: Option<f64>,
+        amount: Amount,
+        price: Option<Price>,
     ) -> Result<Order> {
         let market = self.base().market(symbol).await?;
 

--- a/ccxt-exchanges/tests/binance_conditional_orders_test.rs
+++ b/ccxt-exchanges/tests/binance_conditional_orders_test.rs
@@ -1,3 +1,4 @@
+use ccxt_core::types::financial::{Amount, Price};
 use ccxt_core::{ExchangeConfig, Order, OrderSide, OrderStatus, OrderType};
 use ccxt_exchanges::binance::Binance;
 use rust_decimal_macros::dec;
@@ -20,8 +21,8 @@ async fn test_create_stop_loss_market_order() {
         .create_stop_loss_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            45000.0,
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(45000.0)),
             None, // Market order
             None,
         )
@@ -65,9 +66,9 @@ async fn test_create_stop_loss_limit_order() {
         .create_stop_loss_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            45000.0,
-            Some(44900.0), // Limit price
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(45000.0)),
+            Some(Price::new(dec!(44900.0))), // Limit price
             None,
         )
         .await;
@@ -109,8 +110,8 @@ async fn test_create_take_profit_market_order() {
         .create_take_profit_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            55000.0,
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(55000.0)),
             None, // Market order
             None,
         )
@@ -154,9 +155,9 @@ async fn test_create_take_profit_limit_order() {
         .create_take_profit_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            55000.0,
-            Some(55100.0), // Limit price
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(55000.0)),
+            Some(Price::new(dec!(55100.0))), // Limit price
             None,
         )
         .await;
@@ -201,8 +202,8 @@ async fn test_create_trailing_stop_order_spot() {
         .create_trailing_stop_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            1.5, // 1.5% callback rate
+            Amount::new(dec!(0.001)),
+            dec!(1.5), // 1.5% callback rate
             None,
             None,
         )
@@ -242,9 +243,9 @@ async fn test_create_trailing_stop_order_with_activation() {
         .create_trailing_stop_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            1.5,           // 1.5% callback rate
-            Some(52000.0), // Activation price
+            Amount::new(dec!(0.001)),
+            dec!(1.5),                       // 1.5% callback rate
+            Some(Price::new(dec!(52000.0))), // Activation price
             None,
         )
         .await;
@@ -292,8 +293,8 @@ async fn test_create_order_with_stop_loss() {
             "BTC/USDT",
             OrderType::StopLossLimit,
             OrderSide::Sell,
-            0.001,
-            Some(44900.0),
+            Amount::new(dec!(0.001)),
+            Some(Price::new(dec!(44900.0))),
             Some(params),
         )
         .await;
@@ -340,7 +341,7 @@ async fn test_create_order_with_trailing_stop() {
             "BTC/USDT",
             OrderType::TrailingStop,
             OrderSide::Sell,
-            0.001,
+            Amount::new(dec!(0.001)),
             None,
             Some(params),
         )
@@ -384,8 +385,8 @@ async fn test_stop_loss_order_validation() {
             "BTC/USDT",
             OrderType::StopLossLimit,
             OrderSide::Sell,
-            0.001,
-            Some(44900.0),
+            Amount::new(dec!(0.001)),
+            Some(Price::new(dec!(44900.0))),
             None, // Missing stopPrice
         )
         .await;
@@ -412,7 +413,7 @@ async fn test_trailing_stop_order_validation() {
             "BTC/USDT",
             OrderType::TrailingStop,
             OrderSide::Sell,
-            0.001,
+            Amount::new(dec!(0.001)),
             None,
             None, // Missing trailingPercent
         )
@@ -446,8 +447,8 @@ async fn test_stop_price_mapping() {
             "BTC/USDT",
             OrderType::StopLossLimit,
             OrderSide::Sell,
-            0.001,
-            Some(44900.0),
+            Amount::new(dec!(0.001)),
+            Some(Price::new(dec!(44900.0))),
             Some(params),
         )
         .await;
@@ -484,8 +485,8 @@ async fn test_trailing_stop_futures() {
         .create_trailing_stop_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            1.5, // 将被转换为callbackRate
+            Amount::new(dec!(0.001)),
+            dec!(1.5), // 将被转换为callbackRate
             None,
             Some(params),
         )
@@ -577,8 +578,8 @@ mod integration_tests {
                 "BTC/USDT",
                 OrderType::Limit,
                 OrderSide::Buy,
-                0.001,
-                Some(50000.0),
+                Amount::new(dec!(0.001)),
+                Some(Price::new(dec!(50000.0))),
                 None,
             )
             .await;
@@ -591,9 +592,9 @@ mod integration_tests {
             .create_stop_loss_order(
                 "BTC/USDT",
                 OrderSide::Sell,
-                0.001,
-                48000.0,       // 止损价格
-                Some(47900.0), // 限价
+                Amount::new(dec!(0.001)),
+                Price::new(dec!(48000.0)),       // 止损价格
+                Some(Price::new(dec!(47900.0))), // 限价
                 None,
             )
             .await;
@@ -606,9 +607,9 @@ mod integration_tests {
             .create_take_profit_order(
                 "BTC/USDT",
                 OrderSide::Sell,
-                0.001,
-                55000.0,       // 止盈价格
-                Some(55100.0), // 限价
+                Amount::new(dec!(0.001)),
+                Price::new(dec!(55000.0)),       // 止盈价格
+                Some(Price::new(dec!(55100.0))), // 限价
                 None,
             )
             .await;

--- a/examples/binance_conditional_orders_example.rs
+++ b/examples/binance_conditional_orders_example.rs
@@ -2,8 +2,10 @@
 #![allow(unused_variables)]
 
 use ccxt_core::ExchangeConfig;
+use ccxt_core::types::{Amount, Price};
 use ccxt_core::types::{OrderSide, OrderType};
 use ccxt_exchanges::binance::Binance;
+use rust_decimal_macros::dec;
 use std::collections::HashMap;
 
 #[tokio::main]
@@ -38,7 +40,14 @@ async fn example_1_market_stop_loss(exchange: &Binance) -> Result<(), Box<dyn st
     println!("Scenario: Sell 0.001 BTC at market price when BTC drops to 45000 USDT");
 
     match exchange
-        .create_stop_loss_order("BTC/USDT", OrderSide::Sell, 0.001, 45000.0, None, None)
+        .create_stop_loss_order(
+            "BTC/USDT",
+            OrderSide::Sell,
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(45000.0)),
+            None,
+            None,
+        )
         .await
     {
         Ok(order) => {
@@ -64,9 +73,9 @@ async fn example_2_limit_stop_loss(exchange: &Binance) -> Result<(), Box<dyn std
         .create_stop_loss_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            45000.0,
-            Some(44900.0),
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(45000.0)),
+            Some(Price::new(dec!(44900.0))),
             None,
         )
         .await
@@ -93,7 +102,14 @@ async fn example_3_market_take_profit(
     println!("Scenario: Sell at market price when BTC rises to 55000");
 
     match exchange
-        .create_take_profit_order("BTC/USDT", OrderSide::Sell, 0.001, 55000.0, None, None)
+        .create_take_profit_order(
+            "BTC/USDT",
+            OrderSide::Sell,
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(55000.0)),
+            None,
+            None,
+        )
         .await
     {
         Ok(order) => {
@@ -118,9 +134,9 @@ async fn example_4_limit_take_profit(exchange: &Binance) -> Result<(), Box<dyn s
         .create_take_profit_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            55000.0,
-            Some(55100.0),
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(55000.0)),
+            Some(Price::new(dec!(55100.0))),
             None,
         )
         .await
@@ -145,7 +161,14 @@ async fn example_5_trailing_stop(exchange: &Binance) -> Result<(), Box<dyn std::
     println!("Scenario: Follows price upward, triggers on 1.5% pullback");
 
     match exchange
-        .create_trailing_stop_order("BTC/USDT", OrderSide::Sell, 0.001, 1.5, None, None)
+        .create_trailing_stop_order(
+            "BTC/USDT",
+            OrderSide::Sell,
+            Amount::new(dec!(0.001)),
+            dec!(1.5),
+            None,
+            None,
+        )
         .await
     {
         Ok(order) => {
@@ -172,7 +195,14 @@ async fn example_6_trailing_stop_with_activation(
     println!("Scenario: Start tracking after price reaches 52000");
 
     match exchange
-        .create_trailing_stop_order("BTC/USDT", OrderSide::Sell, 0.001, 1.5, Some(52000.0), None)
+        .create_trailing_stop_order(
+            "BTC/USDT",
+            OrderSide::Sell,
+            Amount::new(dec!(0.001)),
+            dec!(1.5),
+            Some(Price::new(dec!(52000.0))),
+            None,
+        )
         .await
     {
         Ok(order) => {
@@ -202,8 +232,8 @@ async fn example_7_create_order_method(
             "BTC/USDT",
             OrderType::StopLossLimit,
             OrderSide::Sell,
-            0.001,
-            Some(44900.0),
+            Amount::new(dec!(0.001)),
+            Some(Price::new(dec!(44900.0))),
             Some(stop_params),
         )
         .await
@@ -225,7 +255,7 @@ async fn example_7_create_order_method(
             "BTC/USDT",
             OrderType::TrailingStop,
             OrderSide::Sell,
-            0.001,
+            Amount::new(dec!(0.001)),
             None,
             Some(trailing_params),
         )
@@ -255,8 +285,8 @@ async fn example_8_complete_strategy(exchange: &Binance) -> Result<(), Box<dyn s
             "BTC/USDT",
             OrderType::Limit,
             OrderSide::Buy,
-            0.001,
-            Some(50000.0),
+            Amount::new(dec!(0.001)),
+            Some(Price::new(dec!(50000.0))),
             None,
         )
         .await
@@ -275,9 +305,9 @@ async fn example_8_complete_strategy(exchange: &Binance) -> Result<(), Box<dyn s
         .create_stop_loss_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            48000.0,
-            Some(47900.0),
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(48000.0)),
+            Some(Price::new(dec!(47900.0))),
             None,
         )
         .await
@@ -296,9 +326,9 @@ async fn example_8_complete_strategy(exchange: &Binance) -> Result<(), Box<dyn s
         .create_take_profit_order(
             "BTC/USDT",
             OrderSide::Sell,
-            0.001,
-            55000.0,
-            Some(55100.0),
+            Amount::new(dec!(0.001)),
+            Price::new(dec!(55000.0)),
+            Some(Price::new(dec!(55100.0))),
             None,
         )
         .await

--- a/examples/binance_order_management_example.rs
+++ b/examples/binance_order_management_example.rs
@@ -9,8 +9,10 @@
 #![allow(clippy::disallowed_methods)]
 #![allow(clippy::collapsible_if)]
 
+use ccxt_core::types::{Amount, Price};
 use ccxt_core::{ExchangeConfig, OrderSide, OrderType};
 use ccxt_exchanges::binance::Binance;
+use rust_decimal_macros::dec;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -64,8 +66,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "BTC/USDT",
                 OrderType::Limit,
                 OrderSide::Buy,
-                0.001,
-                Some(30000.0), // Very low price, won't fill
+                Amount::new(dec!(0.001)),
+                Some(Price::new(dec!(30000.0))), // Very low price, won't fill
                 None,
             )
             .await

--- a/tests/integration/binance/test_oco_orders.rs
+++ b/tests/integration/binance/test_oco_orders.rs
@@ -8,8 +8,9 @@
 //! 5. 创建测试订单
 //! 6. 修改现有订单
 
-use ccxt_core::{ExchangeConfig, types::{OrderSide, OrderType, OrderStatus}};
+use ccxt_core::{ExchangeConfig, types::{Amount, Price, OrderSide, OrderType, OrderStatus}};
 use ccxt_exchanges::binance::Binance;
+use rust_decimal_macros::dec;
 
 /// 创建测试用的Binance实例
 fn create_test_binance() -> Binance {
@@ -284,8 +285,8 @@ async fn test_edit_order() {
         "BTC/USDT",
         OrderType::Limit,
         OrderSide::Buy,
-        rust_decimal::Decimal::from_f64_retain(0.001).unwrap(),
-        Some(rust_decimal::Decimal::from_f64_retain(35000.0).unwrap()),
+        Amount::new(dec!(0.001)),
+        Some(Price::new(dec!(35000.0))),
         None,
     ).await;
     
@@ -303,8 +304,8 @@ async fn test_edit_order() {
             "BTC/USDT",
             OrderType::Limit,
             OrderSide::Buy,
-            rust_decimal::Decimal::from_f64_retain(0.001).unwrap(),
-            Some(rust_decimal::Decimal::from_f64_retain(34000.0).unwrap()),
+            Amount::new(dec!(0.001)),
+            Some(Price::new(dec!(34000.0))),
             None,
         ).await;
         

--- a/tests/integration/binance/test_order_enhancement.rs
+++ b/tests/integration/binance/test_order_enhancement.rs
@@ -2,19 +2,37 @@
 //!
 //! 测试新增的3个订单相关方法
 
-use ccxt_exchanges::Binance;
-use ccxt_core::types::{OrderSide, OrderType, OrderStatus};
+use ccxt_core::{ExchangeConfig, types::{Amount, Price, OrderSide, OrderType, OrderStatus}};
+use ccxt_exchanges::binance::Binance;
+use rust_decimal_macros::dec;
 use std::collections::HashMap;
+
+/// 创建测试用的Binance实例
+fn create_test_binance() -> Binance {
+    let config = ExchangeConfig {
+        api_key: std::env::var("BINANCE_API_KEY").ok(),
+        secret: std::env::var("BINANCE_API_SECRET").ok(),
+        ..Default::default()
+    };
+    Binance::new(config).expect("Failed to create Binance instance")
+}
+
+/// 创建测试网Binance实例
+fn create_testnet_binance() -> Binance {
+    let config = ExchangeConfig {
+        api_key: std::env::var("BINANCE_API_KEY").ok(),
+        secret: std::env::var("BINANCE_API_SECRET").ok(),
+        sandbox: true,
+        ..Default::default()
+    };
+    Binance::new(config).expect("Failed to create Binance instance")
+}
 
 /// 测试 fetch_order_trades() - 查询订单成交记录
 #[tokio::test]
 #[ignore] // 需要有效的API密钥和真实订单ID
 async fn test_fetch_order_trades() {
-    let mut config = HashMap::new();
-    config.insert("apiKey".to_string(), std::env::var("BINANCE_API_KEY").unwrap());
-    config.insert("secret".to_string(), std::env::var("BINANCE_API_SECRET").unwrap());
-    
-    let exchange = Binance::new(config);
+    let exchange = create_test_binance();
     
     // 需要一个真实的订单ID
     let order_id = "12345678";
@@ -46,11 +64,7 @@ async fn test_fetch_order_trades() {
 #[tokio::test]
 #[ignore] // 需要有效的API密钥
 async fn test_fetch_canceled_orders() {
-    let mut config = HashMap::new();
-    config.insert("apiKey".to_string(), std::env::var("BINANCE_API_KEY").unwrap());
-    config.insert("secret".to_string(), std::env::var("BINANCE_API_SECRET").unwrap());
-    
-    let exchange = Binance::new(config);
+    let exchange = create_test_binance();
     
     let symbol = "BTC/USDT";
     let mut params = HashMap::new();
@@ -83,11 +97,7 @@ async fn test_fetch_canceled_orders() {
 #[tokio::test]
 #[ignore] // 需要有效的API密钥
 async fn test_fetch_canceled_orders_no_symbol() {
-    let mut config = HashMap::new();
-    config.insert("apiKey".to_string(), std::env::var("BINANCE_API_KEY").unwrap());
-    config.insert("secret".to_string(), std::env::var("BINANCE_API_SECRET").unwrap());
-    
-    let exchange = Binance::new(config);
+    let exchange = create_test_binance();
     
     let mut params = HashMap::new();
     params.insert("limit".to_string(), "5".to_string());
@@ -116,13 +126,7 @@ async fn test_fetch_canceled_orders_no_symbol() {
 #[tokio::test]
 #[ignore] // 需要有效的API密钥且会产生真实交易
 async fn test_create_market_buy_order_with_cost() {
-    let mut config = HashMap::new();
-    config.insert("apiKey".to_string(), std::env::var("BINANCE_API_KEY").unwrap());
-    config.insert("secret".to_string(), std::env::var("BINANCE_API_SECRET").unwrap());
-    // 使用测试网
-    config.insert("testnet".to_string(), "true".to_string());
-    
-    let exchange = Binance::new(config);
+    let exchange = create_testnet_binance();
     
     let symbol = "BTC/USDT";
     let cost = 10.0; // 花费10 USDT
@@ -153,11 +157,7 @@ async fn test_create_market_buy_order_with_cost() {
 #[tokio::test]
 #[ignore] // 需要有效的API密钥
 async fn test_create_market_buy_order_with_cost_futures_error() {
-    let mut config = HashMap::new();
-    config.insert("apiKey".to_string(), std::env::var("BINANCE_API_KEY").unwrap());
-    config.insert("secret".to_string(), std::env::var("BINANCE_API_SECRET").unwrap());
-    
-    let exchange = Binance::new(config);
+    let exchange = create_test_binance();
     
     // 尝试在合约市场使用此方法
     let symbol = "BTC/USDT:USDT"; // 合约交易对
@@ -177,12 +177,7 @@ async fn test_create_market_buy_order_with_cost_futures_error() {
 #[tokio::test]
 #[ignore] // 需要有效的API密钥且会产生真实交易
 async fn test_create_order_with_cost_param() {
-    let mut config = HashMap::new();
-    config.insert("apiKey".to_string(), std::env::var("BINANCE_API_KEY").unwrap());
-    config.insert("secret".to_string(), std::env::var("BINANCE_API_SECRET").unwrap());
-    config.insert("testnet".to_string(), "true".to_string());
-    
-    let exchange = Binance::new(config);
+    let exchange = create_testnet_binance();
     
     let symbol = "ETH/USDT";
     let cost = 10.0;
@@ -194,7 +189,7 @@ async fn test_create_order_with_cost_param() {
         symbol,
         OrderType::Market,
         OrderSide::Buy,
-        cost, // 这个参数会被忽略
+        Amount::new(dec!(0.0)), // 这个参数会被忽略，使用cost参数
         None,
         Some(params)
     ).await;
@@ -219,11 +214,7 @@ async fn test_create_order_with_cost_param() {
 #[tokio::test]
 #[ignore] // 需要有效的API密钥
 async fn test_fetch_order_trades_futures_error() {
-    let mut config = HashMap::new();
-    config.insert("apiKey".to_string(), std::env::var("BINANCE_API_KEY").unwrap());
-    config.insert("secret".to_string(), std::env::var("BINANCE_API_SECRET").unwrap());
-    
-    let exchange = Binance::new(config);
+    let exchange = create_test_binance();
     
     // 尝试查询合约订单的成交记录
     let order_id = "12345678";


### PR DESCRIPTION
…ount and Price wrappers

- Replace Decimal type with Amount and Price type-safe wrappers in create_order methods
- Update all exchange implementations (Binance, Bitget, HyperLiquid, Okx) to use new types
- Modify example files to use Amount::new() and Price::new() with rust_decimal_macros
- Update test files to use the new type-safe amount and price parameters
- Remove f64 conversion logic and direct delegation to underlying exchange methods
- Update documentation comments to reflect the new Amount and Price type usage