### PR TITLE
chore(deps): update reqwest dependency and TLS feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures-util = "0.3"
 async-trait = "0.1"
 
 # HTTP & WebSocket
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "gzip"] }
 tokio-tungstenite = { version = "0.28", default-features = false, features = ["rustls-tls-native-roots", "connect"] }
 
 # Serialization

--- a/ccxt-core/Cargo.toml
+++ b/ccxt-core/Cargo.toml
@@ -84,7 +84,7 @@ default = ["rustls-tls", "websocket"]
 
 # TLS implementations (mutually exclusive, choose one)
 rustls-tls = [
-    "reqwest/rustls-tls",
+    "reqwest/rustls",
     "tokio-tungstenite?/rustls-tls-native-roots",
     "tokio-tungstenite?/connect"
 ]

--- a/ccxt-exchanges/Cargo.toml
+++ b/ccxt-exchanges/Cargo.toml
@@ -70,7 +70,7 @@ default = ["binance", "rustls-tls", "websocket"]
 # TLS implementations (mutually exclusive, choose one)
 rustls-tls = [
     "ccxt-core/rustls-tls",
-    "reqwest/rustls-tls",
+    "reqwest/rustls",
     "tokio-tungstenite?/rustls-tls-native-roots",
     "tokio-tungstenite?/connect"
 ]


### PR DESCRIPTION
- Update reqwest from version 0.12 to 0.13
- Change TLS feature flag from rustls-tls to rustls
- Update TLS configuration in ccxt-core and ccxt-exchanges crates
- Maintain compatibility with rustls-tls-native-roots for WebSocket connections