### PR TITLE
refactor(exchanges): update test configurations and enhance ws client…

### DIFF
--- a/ccxt-exchanges/src/binance/signing_strategy.rs
+++ b/ccxt-exchanges/src/binance/signing_strategy.rs
@@ -94,7 +94,7 @@ mod tests {
     fn test_signing_strategy_creation() {
         let config = ExchangeConfig::default();
         let binance = Arc::new(Binance::new(config).unwrap());
-        let strategy = BinanceSigningStrategy::new(binance);
+        let _strategy = BinanceSigningStrategy::new(binance);
         // Strategy created successfully
         assert!(true);
     }

--- a/ccxt-exchanges/src/binance/ws/handlers.rs
+++ b/ccxt-exchanges/src/binance/ws/handlers.rs
@@ -152,12 +152,7 @@ impl MessageRouter {
             .request_id
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-        #[allow(clippy::disallowed_methods)]
-        let request = serde_json::json!({
-            "method": "SUBSCRIBE",
-            "params": streams,
-            "id": id
-        });
+        let request = super::build_binance_subscribe_payload(streams, id);
 
         client
             .send(tokio_tungstenite::tungstenite::protocol::Message::Text(
@@ -183,12 +178,7 @@ impl MessageRouter {
             .request_id
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-        #[allow(clippy::disallowed_methods)]
-        let request = serde_json::json!({
-            "method": "UNSUBSCRIBE",
-            "params": streams,
-            "id": id
-        });
+        let request = super::build_binance_unsubscribe_payload(streams, id);
 
         client
             .send(tokio_tungstenite::tungstenite::protocol::Message::Text(

--- a/ccxt-exchanges/src/bitget/rest/mod.rs
+++ b/ccxt-exchanges/src/bitget/rest/mod.rs
@@ -269,6 +269,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_get_timestamp() {
         let _bitget = Bitget::builder().build().unwrap();
         let ts = Bitget::get_timestamp();

--- a/ccxt-exchanges/src/bybit/rest.rs
+++ b/ccxt-exchanges/src/bybit/rest.rs
@@ -1285,6 +1285,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_get_timestamp() {
         let _bybit = Bybit::builder().build().unwrap();
         let ts = Bybit::get_timestamp();

--- a/ccxt-exchanges/src/lib.rs
+++ b/ccxt-exchanges/src/lib.rs
@@ -82,9 +82,12 @@ pub use ccxt_core;
 ///
 /// This module is deprecated. Use `ccxt_core::Exchange` and
 /// `ccxt_core::ExchangeCapabilities` directly instead.
-#[deprecated(
-    since = "0.2.0",
-    note = "Use `ccxt_core::Exchange` and `ccxt_core::ExchangeCapabilities` directly instead."
+#[cfg_attr(
+    not(test),
+    deprecated(
+        since = "0.2.0",
+        note = "Use `ccxt_core::Exchange` and `ccxt_core::ExchangeCapabilities` directly instead."
+    )
 )]
 pub mod exchange;
 

--- a/ccxt-exchanges/src/okx/rest/mod.rs
+++ b/ccxt-exchanges/src/okx/rest/mod.rs
@@ -306,6 +306,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_get_timestamp() {
         let _okx = Okx::builder().build().unwrap();
         let ts = Okx::get_timestamp();

--- a/ccxt-exchanges/tests/binance_advanced_market_data_test.rs
+++ b/ccxt-exchanges/tests/binance_advanced_market_data_test.rs
@@ -7,7 +7,6 @@
 
 use ccxt_core::ExchangeConfig;
 use ccxt_exchanges::binance::Binance;
-use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 
 /// Create Binance client for testing.
@@ -44,6 +43,7 @@ fn create_authenticated_binance_client() -> Binance {
 mod ohlcv_tests {
     use super::*;
 
+    #[allow(deprecated)]
     #[tokio::test]
     #[ignore] // Requires network connection
     async fn test_fetch_ohlcv_basic() {
@@ -76,6 +76,7 @@ mod ohlcv_tests {
         assert!(first.low <= first.close, "Low should be <= close");
     }
 
+    #[allow(deprecated)]
     #[tokio::test]
     #[ignore] // Requires network connection
     async fn test_fetch_ohlcv_different_timeframes() {
@@ -98,6 +99,7 @@ mod ohlcv_tests {
         }
     }
 
+    #[allow(deprecated)]
     #[tokio::test]
     #[ignore] // Requires network connection
     async fn test_fetch_ohlcv_with_since() {

--- a/ccxt-exchanges/tests/binance_conditional_orders_test.rs
+++ b/ccxt-exchanges/tests/binance_conditional_orders_test.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use ccxt_core::types::financial::{Amount, Price};
 use ccxt_core::{ExchangeConfig, Order, OrderSide, OrderStatus, OrderType};
 use ccxt_exchanges::binance::Binance;

--- a/ccxt-exchanges/tests/binance_integration_test.rs
+++ b/ccxt-exchanges/tests/binance_integration_test.rs
@@ -157,6 +157,7 @@ async fn test_fetch_trades_real() {
 }
 
 /// Test fetching OHLCV (candlestick) data from the real API.
+#[allow(deprecated)]
 #[tokio::test]
 #[ignore]
 async fn test_fetch_ohlcv_real() {
@@ -195,6 +196,7 @@ async fn test_invalid_symbol() {
 }
 
 /// Test handling of unsupported timeframe (2h is not supported by Binance).
+#[allow(deprecated)]
 #[tokio::test]
 #[ignore]
 async fn test_unsupported_timeframe() {

--- a/ccxt-exchanges/tests/binance_my_trades_test.rs
+++ b/ccxt-exchanges/tests/binance_my_trades_test.rs
@@ -17,18 +17,6 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    /// Create a Binance instance for testing.
-    fn create_test_binance() -> Result<Arc<Binance>> {
-        let config = ExchangeConfig {
-            id: "binance".to_string(),
-            name: "Binance".to_string(),
-            api_key: Some(ccxt_core::SecretString::new("test_api_key")),
-            secret: Some(ccxt_core::SecretString::new("test_api_secret")),
-            ..Default::default()
-        };
-        Ok(Arc::new(Binance::new(config)?))
-    }
-
     #[tokio::test]
     #[ignore]
     async fn test_watch_my_trades_all_symbols() -> Result<()> {

--- a/ccxt-exchanges/tests/bitget_integration_test.rs
+++ b/ccxt-exchanges/tests/bitget_integration_test.rs
@@ -267,6 +267,7 @@ async fn test_fetch_trades() {
 
 /// Test fetching OHLCV (candlestick) data from real API.
 /// _Requirements: 5.1_
+#[allow(deprecated)]
 #[tokio::test]
 #[ignore] // Requires network access
 async fn test_fetch_ohlcv() {

--- a/ccxt-exchanges/tests/bybit_integration_test.rs
+++ b/ccxt-exchanges/tests/bybit_integration_test.rs
@@ -258,6 +258,7 @@ async fn test_fetch_trades() {
 }
 
 /// Test fetching OHLCV (candlestick) data from the real API.
+#[allow(deprecated)]
 #[tokio::test]
 #[ignore] // Requires network access
 async fn test_fetch_ohlcv() {

--- a/ccxt-exchanges/tests/hyperliquid_integration_test.rs
+++ b/ccxt-exchanges/tests/hyperliquid_integration_test.rs
@@ -4,7 +4,7 @@
 //! Run with: cargo test --test hyperliquid_integration_test -- --ignored
 
 use ccxt_core::exchange::Exchange;
-use ccxt_exchanges::hyperliquid::{HyperLiquid, HyperLiquidBuilder};
+use ccxt_exchanges::hyperliquid::HyperLiquidBuilder;
 
 /// Test creating a HyperLiquid instance without authentication.
 #[test]

--- a/ccxt-exchanges/tests/okx_bybit_shared_property_test.rs
+++ b/ccxt-exchanges/tests/okx_bybit_shared_property_test.rs
@@ -3,7 +3,6 @@
 //! These tests verify correctness properties that apply to both exchanges using proptest.
 
 use base64::Engine;
-use ccxt_core::SecretString;
 use proptest::prelude::*;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::FromStr;
@@ -1558,7 +1557,7 @@ mod order_status_mapping {
 /// SHALL produce an equivalent Market struct.
 mod market_data_roundtrip {
     use super::*;
-    use ccxt_core::types::{Market, MarketLimits, MarketPrecision, MarketType, MinMax};
+    use ccxt_core::types::{Market, MarketLimits, MarketPrecision, MarketType};
     use rust_decimal::prelude::FromPrimitive;
 
     // Strategy for generating valid market types
@@ -1658,7 +1657,7 @@ mod market_data_roundtrip {
 mod ticker_data_roundtrip {
     use super::*;
     use ccxt_core::types::Ticker;
-    use ccxt_core::types::financial::{Amount, Price};
+    use ccxt_core::types::financial::Price;
     use rust_decimal::prelude::FromPrimitive;
 
     // Strategy for generating valid symbols
@@ -1711,6 +1710,10 @@ mod ticker_data_roundtrip {
                 average: None,
                 base_volume: None,
                 quote_volume: None,
+                funding_rate: None,
+                open_interest: None,
+                index_price: None,
+                mark_price: None,
                 info: std::collections::HashMap::new(),
             };
 

--- a/ccxt-exchanges/tests/okx_integration_test.rs
+++ b/ccxt-exchanges/tests/okx_integration_test.rs
@@ -231,6 +231,7 @@ async fn test_fetch_trades() {
 }
 
 /// Test fetching OHLCV (candlestick) data from the real API.
+#[allow(deprecated)]
 #[tokio::test]
 #[ignore] // Requires network access
 async fn test_fetch_ohlcv() {


### PR DESCRIPTION
… functionality

- Remove unused Decimal import from binance advanced market data tests
- Add deprecated attribute allowances to OHLCV test functions across multiple test files
- Remove unused create_test_binance function from binance my trades test
- Remove unused SecretString imports from property tests
- Add optional fields to Market struct initialization in property tests
- Replace direct market cache access with getter methods in bitget property tests
- Update deprecated method calls to use new getter methods in bitget property tests
- Add #[allow(deprecated)] to various test functions to suppress warnings
- Remove unused HyperLiquid import from hyperliquid integration test
- Conditionally apply deprecated attribute to exchange module outside test builds
- Add custom message builder functionality to ws client for flexible subscription handling
- Implement Binance-specific message builders with atomic request ID tracking
- Extract Binance subscribe/unsubscribe payload construction into dedicated functions
- Add unit tests for Binance payload construction functions
- Add deprecated attribute allowance to timestamp test functions
- Remove unused Amount import from OKX/Bybit shared property test