### PR TITLE
feat(exchange): add futures modules and position/funding parsers for …

### DIFF
--- a/ccxt-exchanges/src/binance/rate_limiter.rs
+++ b/ccxt-exchanges/src/binance/rate_limiter.rs
@@ -27,6 +27,7 @@
 //! // Update from response headers
 //! let info = RateLimitInfo {
 //!     used_weight_1m: Some(500),
+//!     used_weight_1s: None,
 //!     order_count_10s: Some(5),
 //!     order_count_1d: Some(1000),
 //!     retry_after: None,
@@ -485,6 +486,7 @@ mod tests {
 
         let info = RateLimitInfo {
             used_weight_1m: Some(500),
+            used_weight_1s: None,
             order_count_10s: Some(5),
             order_count_1d: Some(1000),
             retry_after: None,
@@ -555,6 +557,7 @@ mod tests {
 
         let info = RateLimitInfo {
             used_weight_1m: Some(1000),
+            used_weight_1s: None,
             order_count_10s: Some(50),
             order_count_1d: Some(5000),
             retry_after: Some(10),

--- a/ccxt-exchanges/src/bitget/margin_impl.rs
+++ b/ccxt-exchanges/src/bitget/margin_impl.rs
@@ -1,0 +1,190 @@
+//! Margin trait implementation for Bitget.
+//!
+//! Implements the `Margin` trait from `ccxt-core` for Bitget, providing
+//! position management, leverage configuration, margin mode, and funding rate operations.
+
+use async_trait::async_trait;
+use ccxt_core::{
+    Result,
+    capability::ExchangeCapabilities,
+    traits::{Margin, PublicExchange},
+    types::{
+        FundingRate, FundingRateHistory, Position, Timeframe,
+        params::{LeverageParams, MarginMode},
+    },
+};
+
+use super::Bitget;
+
+// ============================================================================
+// PublicExchange Implementation
+// ============================================================================
+
+impl PublicExchange for Bitget {
+    fn id(&self) -> &'static str {
+        "bitget"
+    }
+
+    fn name(&self) -> &'static str {
+        "Bitget"
+    }
+
+    fn version(&self) -> &'static str {
+        "v2"
+    }
+
+    fn certified(&self) -> bool {
+        false
+    }
+
+    fn capabilities(&self) -> ExchangeCapabilities {
+        use ccxt_core::exchange::Capability;
+
+        ExchangeCapabilities::builder()
+            // Market Data
+            .market_data()
+            .without_capability(Capability::FetchCurrencies)
+            .without_capability(Capability::FetchStatus)
+            .without_capability(Capability::FetchTime)
+            // Trading
+            .trading()
+            .without_capability(Capability::CancelAllOrders)
+            .without_capability(Capability::EditOrder)
+            .without_capability(Capability::FetchOrders)
+            .without_capability(Capability::FetchCanceledOrders)
+            // Account
+            .capability(Capability::FetchBalance)
+            .capability(Capability::FetchMyTrades)
+            // Margin / Futures
+            .capability(Capability::FetchPositions)
+            .capability(Capability::SetLeverage)
+            .capability(Capability::SetMarginMode)
+            .capability(Capability::FetchFundingRate)
+            .capability(Capability::FetchFundingRates)
+            // WebSocket
+            .capability(Capability::Websocket)
+            .capability(Capability::WatchTicker)
+            .capability(Capability::WatchOrderBook)
+            .capability(Capability::WatchTrades)
+            .capability(Capability::WatchBalance)
+            .capability(Capability::WatchOrders)
+            .capability(Capability::WatchMyTrades)
+            .build()
+    }
+
+    fn timeframes(&self) -> Vec<Timeframe> {
+        vec![
+            Timeframe::M1,
+            Timeframe::M5,
+            Timeframe::M15,
+            Timeframe::M30,
+            Timeframe::H1,
+            Timeframe::H4,
+            Timeframe::H6,
+            Timeframe::H12,
+            Timeframe::D1,
+            Timeframe::D3,
+            Timeframe::W1,
+            Timeframe::Mon1,
+        ]
+    }
+
+    fn rate_limit(&self) -> u32 {
+        20
+    }
+
+    fn has_websocket(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Margin Trait Implementation
+// ============================================================================
+
+#[async_trait]
+impl Margin for Bitget {
+    async fn fetch_positions_for(&self, symbols: &[&str]) -> Result<Vec<Position>> {
+        self.fetch_positions_impl(symbols).await
+    }
+
+    async fn fetch_position(&self, symbol: &str) -> Result<Position> {
+        self.fetch_position_impl(symbol).await
+    }
+
+    async fn set_leverage_with_params(&self, params: LeverageParams) -> Result<()> {
+        let margin_mode = params.margin_mode.map(|m| match m {
+            MarginMode::Isolated => "isolated",
+            MarginMode::Cross => "cross",
+        });
+        self.set_leverage_impl(&params.symbol, params.leverage, margin_mode)
+            .await
+    }
+
+    async fn get_leverage(&self, symbol: &str) -> Result<u32> {
+        self.get_leverage_impl(symbol).await
+    }
+
+    async fn set_margin_mode(&self, symbol: &str, mode: MarginMode) -> Result<()> {
+        let mode_str = match mode {
+            MarginMode::Isolated => "isolated",
+            MarginMode::Cross => "cross",
+        };
+        self.set_margin_mode_impl(symbol, mode_str).await
+    }
+
+    async fn fetch_funding_rate(&self, symbol: &str) -> Result<FundingRate> {
+        self.fetch_funding_rate_impl(symbol).await
+    }
+
+    async fn fetch_funding_rates(&self, symbols: &[&str]) -> Result<Vec<FundingRate>> {
+        self.fetch_funding_rates_impl(symbols).await
+    }
+
+    async fn fetch_funding_rate_history(
+        &self,
+        symbol: &str,
+        since: Option<i64>,
+        limit: Option<u32>,
+    ) -> Result<Vec<FundingRateHistory>> {
+        self.fetch_funding_rate_history_impl(symbol, since, limit)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccxt_core::ExchangeConfig;
+
+    #[test]
+    fn test_bitget_public_exchange_impl() {
+        let bitget = Bitget::new(ExchangeConfig::default()).unwrap();
+        let pe: &dyn PublicExchange = &bitget;
+
+        assert_eq!(pe.id(), "bitget");
+        assert_eq!(pe.name(), "Bitget");
+        assert_eq!(pe.version(), "v2");
+        assert!(!pe.certified());
+        assert!(pe.has_websocket());
+        assert_eq!(pe.rate_limit(), 20);
+    }
+
+    #[test]
+    fn test_bitget_capabilities_include_margin() {
+        let bitget = Bitget::new(ExchangeConfig::default()).unwrap();
+        let caps = PublicExchange::capabilities(&bitget);
+
+        assert!(caps.has("fetchPositions"));
+        assert!(caps.has("setLeverage"));
+        assert!(caps.has("setMarginMode"));
+        assert!(caps.has("fetchFundingRate"));
+        assert!(caps.has("fetchFundingRates"));
+    }
+
+    #[test]
+    fn test_bitget_margin_trait_object_safety() {
+        let bitget = Bitget::new(ExchangeConfig::default()).unwrap();
+        let _margin: Box<dyn Margin> = Box::new(bitget);
+    }
+}

--- a/ccxt-exchanges/src/bitget/mod.rs
+++ b/ccxt-exchanges/src/bitget/mod.rs
@@ -12,9 +12,11 @@ pub mod builder;
 pub mod endpoint_router;
 pub mod error;
 mod exchange_impl;
+mod margin_impl;
 pub mod parser;
 pub mod rest;
 pub mod signed_request;
+pub mod symbol;
 pub mod ws;
 mod ws_exchange_impl;
 
@@ -315,6 +317,16 @@ impl Bitget {
     pub fn create_ws(&self) -> ws::BitgetWs {
         let urls = self.urls();
         ws::BitgetWs::new(urls.ws_public)
+    }
+
+    /// Creates a new private WebSocket client for Bitget.
+    ///
+    /// Returns a `BitgetWs` instance configured with the private WebSocket URL.
+    /// The caller must call `login()` on the returned client before subscribing
+    /// to private channels.
+    pub fn create_private_ws(&self) -> ws::BitgetWs {
+        let urls = self.urls();
+        ws::BitgetWs::new(urls.ws_private)
     }
 
     /// Creates a signed request builder for authenticated API requests.

--- a/ccxt-exchanges/src/bitget/rest/futures/funding.rs
+++ b/ccxt-exchanges/src/bitget/rest/futures/funding.rs
@@ -1,0 +1,99 @@
+//! Funding rate operations for Bitget futures/swap.
+
+use super::super::super::{Bitget, parser, symbol::BitgetSymbolConverter};
+use ccxt_core::{
+    Error, ParseError, Result,
+    types::{FundingRate, FundingRateHistory},
+};
+use std::collections::HashMap;
+use tracing::warn;
+
+impl Bitget {
+    /// Fetch current funding rate for a symbol.
+    ///
+    /// Uses Bitget GET `/api/v2/mix/market/current-fund-rate` (public endpoint).
+    pub async fn fetch_funding_rate_impl(&self, symbol: &str) -> Result<FundingRate> {
+        let exchange_id = BitgetSymbolConverter::unified_to_exchange(symbol);
+        let product_type = BitgetSymbolConverter::product_type_from_symbol(symbol);
+
+        let mut params = HashMap::new();
+        params.insert("symbol".to_string(), exchange_id);
+        params.insert("productType".to_string(), product_type.to_string());
+
+        let data = self
+            .public_request("GET", "/api/v2/mix/market/current-fund-rate", Some(&params))
+            .await?;
+
+        let rates_array = data["data"].as_array().ok_or_else(|| {
+            Error::from(ParseError::invalid_format("data", "Expected data array"))
+        })?;
+
+        if rates_array.is_empty() {
+            return Err(Error::from(ParseError::missing_field_owned(format!(
+                "No funding rate found for symbol: {}",
+                symbol
+            ))));
+        }
+
+        parser::parse_funding_rate(&rates_array[0], symbol)
+    }
+
+    /// Fetch funding rates for multiple symbols.
+    pub async fn fetch_funding_rates_impl(&self, symbols: &[&str]) -> Result<Vec<FundingRate>> {
+        let mut rates = Vec::new();
+        for symbol in symbols {
+            match self.fetch_funding_rate_impl(symbol).await {
+                Ok(rate) => rates.push(rate),
+                Err(e) => {
+                    warn!(error = %e, symbol = %symbol, "Failed to fetch Bitget funding rate");
+                }
+            }
+        }
+        Ok(rates)
+    }
+
+    /// Fetch funding rate history for a symbol.
+    ///
+    /// Uses Bitget GET `/api/v2/mix/market/history-fund-rate` (public endpoint).
+    pub async fn fetch_funding_rate_history_impl(
+        &self,
+        symbol: &str,
+        since: Option<i64>,
+        limit: Option<u32>,
+    ) -> Result<Vec<FundingRateHistory>> {
+        let exchange_id = BitgetSymbolConverter::unified_to_exchange(symbol);
+        let product_type = BitgetSymbolConverter::product_type_from_symbol(symbol);
+
+        let mut params = HashMap::new();
+        params.insert("symbol".to_string(), exchange_id);
+        params.insert("productType".to_string(), product_type.to_string());
+
+        if let Some(l) = limit {
+            params.insert("pageSize".to_string(), l.to_string());
+        }
+
+        if let Some(s) = since {
+            params.insert("startTime".to_string(), s.to_string());
+        }
+
+        let data = self
+            .public_request("GET", "/api/v2/mix/market/history-fund-rate", Some(&params))
+            .await?;
+
+        let history_array = data["data"].as_array().ok_or_else(|| {
+            Error::from(ParseError::invalid_format("data", "Expected data array"))
+        })?;
+
+        let mut history = Vec::new();
+        for item in history_array {
+            match parser::parse_funding_rate_history(item, symbol) {
+                Ok(record) => history.push(record),
+                Err(e) => {
+                    warn!(error = %e, "Failed to parse Bitget funding rate history");
+                }
+            }
+        }
+
+        Ok(history)
+    }
+}

--- a/ccxt-exchanges/src/bitget/rest/futures/leverage.rs
+++ b/ccxt-exchanges/src/bitget/rest/futures/leverage.rs
@@ -1,0 +1,88 @@
+//! Leverage operations for Bitget futures/swap.
+
+use super::super::super::signed_request::HttpMethod;
+use super::super::super::{Bitget, symbol::BitgetSymbolConverter};
+use ccxt_core::{Error, ParseError, Result};
+
+impl Bitget {
+    /// Set leverage for a symbol.
+    ///
+    /// Uses Bitget POST `/api/v2/mix/account/set-leverage` endpoint.
+    pub async fn set_leverage_impl(
+        &self,
+        symbol: &str,
+        leverage: u32,
+        margin_mode: Option<&str>,
+    ) -> Result<()> {
+        let exchange_id = BitgetSymbolConverter::unified_to_exchange(symbol);
+        let product_type = BitgetSymbolConverter::product_type_from_symbol(symbol);
+        let margin_coin = Self::margin_coin_from_symbol(symbol);
+
+        let hold_side = if margin_mode == Some("isolated") {
+            // For isolated mode, set for both sides
+            "long"
+        } else {
+            // For cross mode, no holdSide needed
+            ""
+        };
+
+        let mut builder = self
+            .signed_request("/api/v2/mix/account/set-leverage")
+            .method(HttpMethod::Post)
+            .param("symbol", &exchange_id)
+            .param("productType", product_type)
+            .param("marginCoin", margin_coin)
+            .param("leverage", leverage.to_string());
+
+        if !hold_side.is_empty() {
+            builder = builder.param("holdSide", hold_side);
+        }
+
+        let _data = builder.execute().await?;
+
+        // If isolated mode, also set for short side
+        if margin_mode == Some("isolated") {
+            self.signed_request("/api/v2/mix/account/set-leverage")
+                .method(HttpMethod::Post)
+                .param("symbol", &exchange_id)
+                .param("productType", product_type)
+                .param("marginCoin", margin_coin)
+                .param("leverage", leverage.to_string())
+                .param("holdSide", "short")
+                .execute()
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Get current leverage for a symbol.
+    ///
+    /// Uses Bitget GET `/api/v2/mix/account/account` endpoint and extracts leverage.
+    pub async fn get_leverage_impl(&self, symbol: &str) -> Result<u32> {
+        let exchange_id = BitgetSymbolConverter::unified_to_exchange(symbol);
+        let product_type = BitgetSymbolConverter::product_type_from_symbol(symbol);
+        let margin_coin = Self::margin_coin_from_symbol(symbol);
+
+        let data = self
+            .signed_request("/api/v2/mix/account/account")
+            .param("symbol", &exchange_id)
+            .param("productType", product_type)
+            .param("marginCoin", margin_coin)
+            .execute()
+            .await?;
+
+        // Try to extract leverage from the account data
+        let lever_str = data["data"]["crossMarginLeverage"]
+            .as_str()
+            .or_else(|| data["data"]["fixedLongLeverage"].as_str())
+            .ok_or_else(|| Error::from(ParseError::missing_field("leverage")))?;
+
+        lever_str.parse::<f64>().map(|v| v as u32).map_err(|_| {
+            Error::from(ParseError::invalid_value(
+                "leverage",
+                format!("Cannot parse leverage: {}", lever_str),
+            ))
+        })
+    }
+}

--- a/ccxt-exchanges/src/bitget/rest/futures/margin.rs
+++ b/ccxt-exchanges/src/bitget/rest/futures/margin.rs
@@ -1,0 +1,38 @@
+//! Margin mode operations for Bitget futures/swap.
+
+use super::super::super::signed_request::HttpMethod;
+use super::super::super::{Bitget, symbol::BitgetSymbolConverter};
+use ccxt_core::{Error, Result};
+
+impl Bitget {
+    /// Set margin mode (cross or isolated) for a symbol.
+    ///
+    /// Uses Bitget POST `/api/v2/mix/account/set-margin-mode` endpoint.
+    pub async fn set_margin_mode_impl(&self, symbol: &str, mode: &str) -> Result<()> {
+        let exchange_id = BitgetSymbolConverter::unified_to_exchange(symbol);
+        let product_type = BitgetSymbolConverter::product_type_from_symbol(symbol);
+        let margin_coin = Self::margin_coin_from_symbol(symbol);
+
+        let margin_mode = match mode.to_lowercase().as_str() {
+            "isolated" => "isolated",
+            "cross" | "crossed" => "crossed",
+            _ => {
+                return Err(Error::invalid_request(format!(
+                    "Invalid margin mode: {}. Must be 'isolated' or 'cross'",
+                    mode
+                )));
+            }
+        };
+
+        self.signed_request("/api/v2/mix/account/set-margin-mode")
+            .method(HttpMethod::Post)
+            .param("symbol", &exchange_id)
+            .param("productType", product_type)
+            .param("marginCoin", margin_coin)
+            .param("marginMode", margin_mode)
+            .execute()
+            .await?;
+
+        Ok(())
+    }
+}

--- a/ccxt-exchanges/src/bitget/rest/futures/mod.rs
+++ b/ccxt-exchanges/src/bitget/rest/futures/mod.rs
@@ -1,0 +1,9 @@
+//! Bitget futures/swap operations.
+//!
+//! This module contains methods for managing positions, leverage,
+//! funding rates, and margin mode for Bitget perpetual swaps and futures contracts.
+
+mod funding;
+mod leverage;
+mod margin;
+mod positions;

--- a/ccxt-exchanges/src/bitget/rest/futures/positions.rs
+++ b/ccxt-exchanges/src/bitget/rest/futures/positions.rs
@@ -1,0 +1,121 @@
+//! Position management methods for Bitget futures/swap.
+
+use super::super::super::{Bitget, parser, symbol::BitgetSymbolConverter};
+use ccxt_core::{Error, ParseError, Result, types::Position};
+use tracing::warn;
+
+impl Bitget {
+    /// Fetch a single position for a symbol.
+    ///
+    /// Uses Bitget GET `/api/v2/mix/position/single-position` endpoint.
+    pub async fn fetch_position_impl(&self, symbol: &str) -> Result<Position> {
+        let exchange_id = BitgetSymbolConverter::unified_to_exchange(symbol);
+        let product_type = BitgetSymbolConverter::product_type_from_symbol(symbol);
+
+        let data = self
+            .signed_request("/api/v2/mix/position/single-position")
+            .param("symbol", &exchange_id)
+            .param("productType", product_type)
+            .param("marginCoin", Self::margin_coin_from_symbol(symbol))
+            .execute()
+            .await?;
+
+        let positions_array = data["data"].as_array().ok_or_else(|| {
+            Error::from(ParseError::invalid_format("data", "Expected data array"))
+        })?;
+
+        if positions_array.is_empty() {
+            return Err(Error::from(ParseError::missing_field_owned(format!(
+                "No position found for symbol: {}",
+                symbol
+            ))));
+        }
+
+        parser::parse_position(&positions_array[0], symbol)
+    }
+
+    /// Fetch positions for specific symbols, or all positions if empty.
+    ///
+    /// Uses Bitget GET `/api/v2/mix/position/all-position` endpoint.
+    pub async fn fetch_positions_impl(&self, symbols: &[&str]) -> Result<Vec<Position>> {
+        let product_type = if symbols.is_empty() {
+            self.options().effective_product_type()
+        } else {
+            BitgetSymbolConverter::product_type_from_symbol(symbols[0])
+        };
+
+        let margin_coin = if symbols.is_empty() {
+            "USDT".to_string()
+        } else {
+            Self::margin_coin_from_symbol(symbols[0]).to_string()
+        };
+
+        let data = self
+            .signed_request("/api/v2/mix/position/all-position")
+            .param("productType", product_type)
+            .param("marginCoin", &margin_coin)
+            .execute()
+            .await?;
+
+        let positions_array = data["data"].as_array().ok_or_else(|| {
+            Error::from(ParseError::invalid_format("data", "Expected data array"))
+        })?;
+
+        let mut positions = Vec::new();
+        for position_data in positions_array {
+            let bitget_symbol = position_data["symbol"].as_str().unwrap_or_default();
+            let symbol_hint =
+                BitgetSymbolConverter::exchange_to_unified_hint(bitget_symbol, product_type);
+
+            match parser::parse_position(position_data, &symbol_hint) {
+                Ok(position) => {
+                    if symbols.is_empty() || symbols.contains(&position.symbol.as_str()) {
+                        positions.push(position);
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, symbol = %bitget_symbol, "Failed to parse Bitget position");
+                }
+            }
+        }
+
+        Ok(positions)
+    }
+
+    /// Extract margin coin from a unified symbol.
+    ///
+    /// - "BTC/USDT:USDT" → "USDT"
+    /// - "BTC/USD:BTC" → "BTC"
+    /// - "BTC/USDT" → "USDT" (fallback to quote)
+    pub(crate) fn margin_coin_from_symbol(symbol: &str) -> &str {
+        if let Some(pos) = symbol.find(':') {
+            let settle_part = &symbol[pos + 1..];
+            // Strip expiry date if present
+            if let Some(dash_pos) = settle_part.find('-') {
+                &settle_part[..dash_pos]
+            } else {
+                settle_part
+            }
+        } else if let Some(pos) = symbol.find('/') {
+            &symbol[pos + 1..]
+        } else {
+            "USDT"
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_margin_coin_from_symbol() {
+        assert_eq!(Bitget::margin_coin_from_symbol("BTC/USDT:USDT"), "USDT");
+        assert_eq!(Bitget::margin_coin_from_symbol("BTC/USD:BTC"), "BTC");
+        assert_eq!(Bitget::margin_coin_from_symbol("BTC/USDT"), "USDT");
+        assert_eq!(
+            Bitget::margin_coin_from_symbol("BTC/USDT:USDT-241231"),
+            "USDT"
+        );
+    }
+}

--- a/ccxt-exchanges/src/bitget/rest/mod.rs
+++ b/ccxt-exchanges/src/bitget/rest/mod.rs
@@ -3,6 +3,7 @@
 //! Implements all REST API endpoint operations for the Bitget exchange.
 
 mod account;
+pub mod futures;
 mod market_data;
 mod trading;
 

--- a/ccxt-exchanges/src/bitget/symbol.rs
+++ b/ccxt-exchanges/src/bitget/symbol.rs
@@ -1,0 +1,274 @@
+//! Bitget symbol converter implementation.
+//!
+//! This module provides conversion between unified CCXT symbols and Bitget-specific
+//! exchange IDs for spot, swap (perpetual), and futures markets.
+//!
+//! # Bitget Symbol Formats
+//!
+//! | Market Type | Unified Format | Bitget Format | Product Type |
+//! |-------------|----------------|---------------|--------------|
+//! | Spot | BTC/USDT | BTCUSDT | spot |
+//! | Linear Swap | BTC/USDT:USDT | BTCUSDT | USDT-FUTURES |
+//! | Inverse Swap | BTC/USD:BTC | BTCUSD | COIN-FUTURES |
+//!
+//! # Example
+//!
+//! ```rust
+//! use ccxt_exchanges::bitget::symbol::BitgetSymbolConverter;
+//!
+//! assert_eq!(BitgetSymbolConverter::unified_to_exchange("BTC/USDT"), "BTCUSDT");
+//! assert_eq!(BitgetSymbolConverter::unified_to_exchange("BTC/USDT:USDT"), "BTCUSDT");
+//! assert_eq!(BitgetSymbolConverter::product_type_from_symbol("BTC/USDT:USDT"), "USDT-FUTURES");
+//! assert_eq!(BitgetSymbolConverter::product_type_from_symbol("BTC/USDT"), "spot");
+//! ```
+
+/// Bitget symbol converter.
+///
+/// Provides methods to convert between unified CCXT symbols and Bitget-specific
+/// exchange IDs, and to determine the appropriate product type.
+pub struct BitgetSymbolConverter;
+
+impl BitgetSymbolConverter {
+    /// Convert a unified CCXT symbol to Bitget exchange ID.
+    ///
+    /// Strips the settlement currency suffix and removes separators:
+    /// - "BTC/USDT" → "BTCUSDT"
+    /// - "BTC/USDT:USDT" → "BTCUSDT"
+    /// - "BTC/USD:BTC" → "BTCUSD"
+    /// - "BTC/USDT:USDT-241231" → "BTCUSDT"
+    pub fn unified_to_exchange(symbol: &str) -> String {
+        // Strip settlement part (everything after ':')
+        let base_quote = if let Some(pos) = symbol.find(':') {
+            &symbol[..pos]
+        } else {
+            symbol
+        };
+
+        // Remove the '/' separator
+        base_quote.replace('/', "")
+    }
+
+    /// Determine the Bitget product type from a unified symbol.
+    ///
+    /// Returns:
+    /// - "USDT-FUTURES" for linear perpetual/futures (e.g., "BTC/USDT:USDT")
+    /// - "COIN-FUTURES" for inverse perpetual/futures (e.g., "BTC/USD:BTC")
+    /// - "spot" for spot markets (e.g., "BTC/USDT")
+    pub fn product_type_from_symbol(symbol: &str) -> &'static str {
+        if let Some(pos) = symbol.find(':') {
+            let settle_part = &symbol[pos + 1..];
+            // Strip expiry date if present
+            let settle = if let Some(dash_pos) = settle_part.find('-') {
+                &settle_part[..dash_pos]
+            } else {
+                settle_part
+            };
+
+            // Extract quote currency
+            let base_quote = &symbol[..pos];
+            let quote = if let Some(slash_pos) = base_quote.find('/') {
+                &base_quote[slash_pos + 1..]
+            } else {
+                ""
+            };
+
+            // If settle == quote, it's linear (USDT-FUTURES)
+            // If settle != quote (settle == base), it's inverse (COIN-FUTURES)
+            if settle == quote {
+                "USDT-FUTURES"
+            } else {
+                "COIN-FUTURES"
+            }
+        } else {
+            "spot"
+        }
+    }
+
+    /// Check if a symbol is a contract (has settlement currency).
+    pub fn is_contract(symbol: &str) -> bool {
+        symbol.contains(':')
+    }
+
+    /// Check if a symbol is a spot market.
+    pub fn is_spot(symbol: &str) -> bool {
+        !symbol.contains(':')
+    }
+
+    /// Convert a Bitget exchange ID back to a rough unified symbol hint.
+    ///
+    /// This is a best-effort conversion:
+    /// - "BTCUSDT" with product_type "USDT-FUTURES" → "BTC/USDT:USDT"
+    /// - "BTCUSD" with product_type "COIN-FUTURES" → "BTC/USD:BTC"
+    /// - "BTCUSDT" with product_type "spot" → "BTC/USDT"
+    pub fn exchange_to_unified_hint(exchange_id: &str, product_type: &str) -> String {
+        // Try to split the exchange ID into base and quote
+        // Common quote currencies in order of length (longest first to avoid partial matches)
+        let quote_currencies = ["USDT", "USDC", "USD", "BTC", "ETH"];
+
+        for quote in &quote_currencies {
+            if exchange_id.ends_with(quote) && exchange_id.len() > quote.len() {
+                let base = &exchange_id[..exchange_id.len() - quote.len()];
+                return match product_type {
+                    "USDT-FUTURES" | "usdt-futures" => {
+                        format!("{}/{}:{}", base, quote, quote)
+                    }
+                    "COIN-FUTURES" | "coin-futures" => {
+                        format!("{}/{}:{}", base, quote, base)
+                    }
+                    _ => {
+                        format!("{}/{}", base, quote)
+                    }
+                };
+            }
+        }
+
+        // Fallback: return as-is
+        exchange_id.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // unified_to_exchange tests
+    // ========================================================================
+
+    #[test]
+    fn test_spot_to_exchange() {
+        assert_eq!(
+            BitgetSymbolConverter::unified_to_exchange("BTC/USDT"),
+            "BTCUSDT"
+        );
+        assert_eq!(
+            BitgetSymbolConverter::unified_to_exchange("ETH/USDT"),
+            "ETHUSDT"
+        );
+        assert_eq!(
+            BitgetSymbolConverter::unified_to_exchange("SOL/BTC"),
+            "SOLBTC"
+        );
+    }
+
+    #[test]
+    fn test_linear_swap_to_exchange() {
+        assert_eq!(
+            BitgetSymbolConverter::unified_to_exchange("BTC/USDT:USDT"),
+            "BTCUSDT"
+        );
+        assert_eq!(
+            BitgetSymbolConverter::unified_to_exchange("ETH/USDT:USDT"),
+            "ETHUSDT"
+        );
+    }
+
+    #[test]
+    fn test_inverse_swap_to_exchange() {
+        assert_eq!(
+            BitgetSymbolConverter::unified_to_exchange("BTC/USD:BTC"),
+            "BTCUSD"
+        );
+    }
+
+    #[test]
+    fn test_futures_with_expiry_to_exchange() {
+        assert_eq!(
+            BitgetSymbolConverter::unified_to_exchange("BTC/USDT:USDT-241231"),
+            "BTCUSDT"
+        );
+    }
+
+    // ========================================================================
+    // product_type_from_symbol tests
+    // ========================================================================
+
+    #[test]
+    fn test_product_type_spot() {
+        assert_eq!(
+            BitgetSymbolConverter::product_type_from_symbol("BTC/USDT"),
+            "spot"
+        );
+        assert_eq!(
+            BitgetSymbolConverter::product_type_from_symbol("ETH/BTC"),
+            "spot"
+        );
+    }
+
+    #[test]
+    fn test_product_type_linear() {
+        assert_eq!(
+            BitgetSymbolConverter::product_type_from_symbol("BTC/USDT:USDT"),
+            "USDT-FUTURES"
+        );
+        assert_eq!(
+            BitgetSymbolConverter::product_type_from_symbol("ETH/USDT:USDT"),
+            "USDT-FUTURES"
+        );
+    }
+
+    #[test]
+    fn test_product_type_inverse() {
+        assert_eq!(
+            BitgetSymbolConverter::product_type_from_symbol("BTC/USD:BTC"),
+            "COIN-FUTURES"
+        );
+        assert_eq!(
+            BitgetSymbolConverter::product_type_from_symbol("ETH/USD:ETH"),
+            "COIN-FUTURES"
+        );
+    }
+
+    #[test]
+    fn test_product_type_futures_with_expiry() {
+        assert_eq!(
+            BitgetSymbolConverter::product_type_from_symbol("BTC/USDT:USDT-241231"),
+            "USDT-FUTURES"
+        );
+    }
+
+    // ========================================================================
+    // Helper function tests
+    // ========================================================================
+
+    #[test]
+    fn test_is_contract() {
+        assert!(BitgetSymbolConverter::is_contract("BTC/USDT:USDT"));
+        assert!(BitgetSymbolConverter::is_contract("BTC/USD:BTC"));
+        assert!(!BitgetSymbolConverter::is_contract("BTC/USDT"));
+    }
+
+    #[test]
+    fn test_is_spot() {
+        assert!(BitgetSymbolConverter::is_spot("BTC/USDT"));
+        assert!(!BitgetSymbolConverter::is_spot("BTC/USDT:USDT"));
+    }
+
+    // ========================================================================
+    // exchange_to_unified_hint tests
+    // ========================================================================
+
+    #[test]
+    fn test_exchange_to_unified_spot() {
+        assert_eq!(
+            BitgetSymbolConverter::exchange_to_unified_hint("BTCUSDT", "spot"),
+            "BTC/USDT"
+        );
+    }
+
+    #[test]
+    fn test_exchange_to_unified_linear() {
+        assert_eq!(
+            BitgetSymbolConverter::exchange_to_unified_hint("BTCUSDT", "USDT-FUTURES"),
+            "BTC/USDT:USDT"
+        );
+    }
+
+    #[test]
+    fn test_exchange_to_unified_inverse() {
+        assert_eq!(
+            BitgetSymbolConverter::exchange_to_unified_hint("BTCUSD", "COIN-FUTURES"),
+            "BTC/USD:BTC"
+        );
+    }
+}

--- a/ccxt-exchanges/src/bitget/ws_exchange_impl.rs
+++ b/ccxt-exchanges/src/bitget/ws_exchange_impl.rs
@@ -126,21 +126,24 @@ impl WsExchange for Bitget {
     // ==================== Private Data Streams ====================
 
     async fn watch_balance(&self) -> Result<MessageStream<Balance>> {
-        Err(Error::not_implemented(
-            "watch_balance not yet implemented for Bitget",
-        ))
+        let ws = self.create_private_ws();
+        let auth = self.get_auth()?;
+        ws.login(&auth).await?;
+        ws.watch_balance().await
     }
 
-    async fn watch_orders(&self, _symbol: Option<&str>) -> Result<MessageStream<Order>> {
-        Err(Error::not_implemented(
-            "watch_orders not yet implemented for Bitget",
-        ))
+    async fn watch_orders(&self, symbol: Option<&str>) -> Result<MessageStream<Order>> {
+        let ws = self.create_private_ws();
+        let auth = self.get_auth()?;
+        ws.login(&auth).await?;
+        ws.watch_orders(symbol.map(ToString::to_string)).await
     }
 
-    async fn watch_my_trades(&self, _symbol: Option<&str>) -> Result<MessageStream<Trade>> {
-        Err(Error::not_implemented(
-            "watch_my_trades not yet implemented for Bitget",
-        ))
+    async fn watch_my_trades(&self, symbol: Option<&str>) -> Result<MessageStream<Trade>> {
+        let ws = self.create_private_ws();
+        let auth = self.get_auth()?;
+        ws.login(&auth).await?;
+        ws.watch_my_trades(symbol.map(ToString::to_string)).await
     }
 
     // ==================== Subscription Management ====================

--- a/ccxt-exchanges/src/okx/margin_impl.rs
+++ b/ccxt-exchanges/src/okx/margin_impl.rs
@@ -1,0 +1,192 @@
+//! Margin trait implementation for OKX.
+//!
+//! Implements the `Margin` trait from `ccxt-core` for OKX, providing
+//! position management, leverage configuration, margin mode, and funding rate operations.
+
+use async_trait::async_trait;
+use ccxt_core::{
+    Result,
+    capability::ExchangeCapabilities,
+    traits::{Margin, PublicExchange},
+    types::{
+        FundingRate, FundingRateHistory, Position, Timeframe,
+        params::{LeverageParams, MarginMode},
+    },
+};
+
+use super::Okx;
+
+// ============================================================================
+// PublicExchange Implementation
+// ============================================================================
+
+impl PublicExchange for Okx {
+    fn id(&self) -> &'static str {
+        "okx"
+    }
+
+    fn name(&self) -> &'static str {
+        "OKX"
+    }
+
+    fn version(&self) -> &'static str {
+        "v5"
+    }
+
+    fn certified(&self) -> bool {
+        false
+    }
+
+    fn capabilities(&self) -> ExchangeCapabilities {
+        use ccxt_core::exchange::Capability;
+
+        ExchangeCapabilities::builder()
+            // Market Data
+            .market_data()
+            .without_capability(Capability::FetchCurrencies)
+            .without_capability(Capability::FetchStatus)
+            .without_capability(Capability::FetchTime)
+            // Trading
+            .trading()
+            .without_capability(Capability::CancelAllOrders)
+            .without_capability(Capability::EditOrder)
+            .without_capability(Capability::FetchOrders)
+            .without_capability(Capability::FetchCanceledOrders)
+            // Account
+            .capability(Capability::FetchBalance)
+            .capability(Capability::FetchMyTrades)
+            // Margin / Futures
+            .capability(Capability::FetchPositions)
+            .capability(Capability::SetLeverage)
+            .capability(Capability::SetMarginMode)
+            .capability(Capability::FetchFundingRate)
+            .capability(Capability::FetchFundingRates)
+            // WebSocket
+            .capability(Capability::Websocket)
+            .capability(Capability::WatchTicker)
+            .capability(Capability::WatchOrderBook)
+            .capability(Capability::WatchTrades)
+            .capability(Capability::WatchBalance)
+            .capability(Capability::WatchOrders)
+            .capability(Capability::WatchMyTrades)
+            .build()
+    }
+
+    fn timeframes(&self) -> Vec<Timeframe> {
+        vec![
+            Timeframe::M1,
+            Timeframe::M3,
+            Timeframe::M5,
+            Timeframe::M15,
+            Timeframe::M30,
+            Timeframe::H1,
+            Timeframe::H2,
+            Timeframe::H4,
+            Timeframe::H6,
+            Timeframe::H12,
+            Timeframe::D1,
+            Timeframe::W1,
+            Timeframe::Mon1,
+        ]
+    }
+
+    fn rate_limit(&self) -> u32 {
+        20
+    }
+
+    fn has_websocket(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Margin Trait Implementation
+// ============================================================================
+
+#[async_trait]
+impl Margin for Okx {
+    async fn fetch_positions_for(&self, symbols: &[&str]) -> Result<Vec<Position>> {
+        self.fetch_positions_impl(symbols).await
+    }
+
+    async fn fetch_position(&self, symbol: &str) -> Result<Position> {
+        self.fetch_position_impl(symbol).await
+    }
+
+    async fn set_leverage_with_params(&self, params: LeverageParams) -> Result<()> {
+        let margin_mode = params.margin_mode.map(|m| match m {
+            MarginMode::Isolated => "isolated",
+            MarginMode::Cross => "cross",
+        });
+        self.set_leverage_impl(&params.symbol, params.leverage, margin_mode)
+            .await
+    }
+
+    async fn get_leverage(&self, symbol: &str) -> Result<u32> {
+        self.get_leverage_impl(symbol).await
+    }
+
+    async fn set_margin_mode(&self, symbol: &str, mode: MarginMode) -> Result<()> {
+        let mode_str = match mode {
+            MarginMode::Isolated => "isolated",
+            MarginMode::Cross => "cross",
+        };
+        self.set_margin_mode_impl(symbol, mode_str).await
+    }
+
+    async fn fetch_funding_rate(&self, symbol: &str) -> Result<FundingRate> {
+        self.fetch_funding_rate_impl(symbol).await
+    }
+
+    async fn fetch_funding_rates(&self, symbols: &[&str]) -> Result<Vec<FundingRate>> {
+        self.fetch_funding_rates_impl(symbols).await
+    }
+
+    async fn fetch_funding_rate_history(
+        &self,
+        symbol: &str,
+        since: Option<i64>,
+        limit: Option<u32>,
+    ) -> Result<Vec<FundingRateHistory>> {
+        self.fetch_funding_rate_history_impl(symbol, since, limit)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccxt_core::ExchangeConfig;
+
+    #[test]
+    fn test_okx_public_exchange_impl() {
+        let okx = Okx::new(ExchangeConfig::default()).unwrap();
+        let pe: &dyn PublicExchange = &okx;
+
+        assert_eq!(pe.id(), "okx");
+        assert_eq!(pe.name(), "OKX");
+        assert_eq!(pe.version(), "v5");
+        assert!(!pe.certified());
+        assert!(pe.has_websocket());
+        assert_eq!(pe.rate_limit(), 20);
+    }
+
+    #[test]
+    fn test_okx_capabilities_include_margin() {
+        let okx = Okx::new(ExchangeConfig::default()).unwrap();
+        let caps = PublicExchange::capabilities(&okx);
+
+        assert!(caps.has("fetchPositions"));
+        assert!(caps.has("setLeverage"));
+        assert!(caps.has("setMarginMode"));
+        assert!(caps.has("fetchFundingRate"));
+        assert!(caps.has("fetchFundingRates"));
+    }
+
+    #[test]
+    fn test_okx_margin_trait_object_safety() {
+        let okx = Okx::new(ExchangeConfig::default()).unwrap();
+        // Verify trait is object-safe by creating a trait object
+        let _margin: Box<dyn Margin> = Box::new(okx);
+    }
+}

--- a/ccxt-exchanges/src/okx/mod.rs
+++ b/ccxt-exchanges/src/okx/mod.rs
@@ -13,6 +13,7 @@ pub mod builder;
 pub mod endpoint_router;
 pub mod error;
 pub mod exchange_impl;
+pub mod margin_impl;
 pub mod parser;
 pub mod rest;
 pub mod signed_request;
@@ -330,6 +331,16 @@ impl Okx {
     pub fn create_ws(&self) -> ws::OkxWs {
         let urls = self.urls();
         ws::OkxWs::new(urls.ws_public)
+    }
+
+    /// Creates a new private WebSocket client for OKX.
+    ///
+    /// Returns an `OkxWs` instance configured with the private WebSocket URL.
+    /// The caller must call `login()` on the returned client before subscribing
+    /// to private channels.
+    pub fn create_private_ws(&self) -> ws::OkxWs {
+        let urls = self.urls();
+        ws::OkxWs::new(urls.ws_private)
     }
 
     /// Creates a new signed request builder for authenticated API requests.

--- a/ccxt-exchanges/src/okx/rest/futures/funding.rs
+++ b/ccxt-exchanges/src/okx/rest/futures/funding.rs
@@ -1,0 +1,97 @@
+//! Funding rate operations for OKX futures/swap.
+
+use super::super::super::{Okx, parser};
+use ccxt_core::{
+    Error, ParseError, Result,
+    types::{FundingRate, FundingRateHistory},
+};
+use std::collections::HashMap;
+use tracing::warn;
+
+impl Okx {
+    /// Fetch current funding rate for a symbol.
+    ///
+    /// Uses OKX GET `/api/v5/public/funding-rate` (public endpoint).
+    pub async fn fetch_funding_rate_impl(&self, symbol: &str) -> Result<FundingRate> {
+        let inst_id = Self::symbol_to_inst_id(symbol);
+
+        let mut params = HashMap::new();
+        params.insert("instId".to_string(), inst_id);
+
+        let data = self
+            .public_request("GET", "/api/v5/public/funding-rate", Some(&params))
+            .await?;
+
+        let rates_array = data["data"].as_array().ok_or_else(|| {
+            Error::from(ParseError::invalid_format("data", "Expected data array"))
+        })?;
+
+        if rates_array.is_empty() {
+            return Err(Error::from(ParseError::missing_field_owned(format!(
+                "No funding rate found for symbol: {}",
+                symbol
+            ))));
+        }
+
+        parser::parse_funding_rate(&rates_array[0], symbol)
+    }
+
+    /// Fetch funding rates for multiple symbols.
+    ///
+    /// Calls `fetch_funding_rate_impl` for each symbol.
+    pub async fn fetch_funding_rates_impl(&self, symbols: &[&str]) -> Result<Vec<FundingRate>> {
+        let mut rates = Vec::new();
+        for symbol in symbols {
+            match self.fetch_funding_rate_impl(symbol).await {
+                Ok(rate) => rates.push(rate),
+                Err(e) => {
+                    warn!(error = %e, symbol = %symbol, "Failed to fetch funding rate");
+                }
+            }
+        }
+        Ok(rates)
+    }
+
+    /// Fetch funding rate history for a symbol.
+    ///
+    /// Uses OKX GET `/api/v5/public/funding-rate-history` (public endpoint).
+    pub async fn fetch_funding_rate_history_impl(
+        &self,
+        symbol: &str,
+        since: Option<i64>,
+        limit: Option<u32>,
+    ) -> Result<Vec<FundingRateHistory>> {
+        let inst_id = Self::symbol_to_inst_id(symbol);
+
+        let mut params = HashMap::new();
+        params.insert("instId".to_string(), inst_id);
+
+        if let Some(s) = since {
+            params.insert("before".to_string(), s.to_string());
+        }
+
+        if let Some(l) = limit {
+            params.insert("limit".to_string(), l.to_string());
+        }
+
+        let data = self
+            .public_request("GET", "/api/v5/public/funding-rate-history", Some(&params))
+            .await?;
+
+        let history_array = data["data"].as_array().ok_or_else(|| {
+            Error::from(ParseError::invalid_format("data", "Expected data array"))
+        })?;
+
+        let mut history = Vec::new();
+        for item in history_array {
+            match parser::parse_funding_rate_history(item, symbol) {
+                Ok(record) => history.push(record),
+                Err(e) => {
+                    warn!(error = %e, "Failed to parse OKX funding rate history");
+                }
+            }
+        }
+
+        Ok(history)
+    }
+}

--- a/ccxt-exchanges/src/okx/rest/futures/leverage.rs
+++ b/ccxt-exchanges/src/okx/rest/futures/leverage.rs
@@ -1,0 +1,105 @@
+//! Leverage operations for OKX futures/swap.
+
+use super::super::super::{Okx, signed_request::HttpMethod};
+use ccxt_core::{Error, ParseError, Result};
+
+impl Okx {
+    /// Set leverage for a symbol.
+    ///
+    /// Uses OKX POST `/api/v5/account/set-leverage` endpoint.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - Unified symbol (e.g., "BTC/USDT:USDT")
+    /// * `leverage` - Leverage multiplier
+    /// * `margin_mode` - "cross" or "isolated"
+    pub async fn set_leverage_impl(
+        &self,
+        symbol: &str,
+        leverage: u32,
+        margin_mode: Option<&str>,
+    ) -> Result<()> {
+        let inst_id = Self::symbol_to_inst_id(symbol);
+        let mgn_mode = margin_mode.unwrap_or("cross");
+
+        let mut builder = self
+            .signed_request("/api/v5/account/set-leverage")
+            .method(HttpMethod::Post)
+            .param("instId", &inst_id)
+            .param("lever", leverage.to_string())
+            .param("mgnMode", mgn_mode);
+
+        // For isolated mode, we need to specify posSide
+        if mgn_mode == "isolated" {
+            // Set for both long and short sides
+            builder = builder.param("posSide", "net");
+        }
+
+        let data = builder.execute().await?;
+
+        // Check for nested error in data array
+        if let Some(arr) = data["data"].as_array() {
+            if let Some(first) = arr.first() {
+                if let Some(code) = first["sCode"].as_str() {
+                    if code != "0" {
+                        let msg = first["sMsg"].as_str().unwrap_or("Unknown error");
+                        return Err(Error::exchange(code, msg));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get current leverage for a symbol.
+    ///
+    /// Uses OKX GET `/api/v5/account/leverage-info` endpoint.
+    pub async fn get_leverage_impl(&self, symbol: &str) -> Result<u32> {
+        let inst_id = Self::symbol_to_inst_id(symbol);
+
+        let data = self
+            .signed_request("/api/v5/account/leverage-info")
+            .param("instId", &inst_id)
+            .param("mgnMode", "cross")
+            .execute()
+            .await?;
+
+        let leverage_array = data["data"].as_array().ok_or_else(|| {
+            Error::from(ParseError::invalid_format("data", "Expected data array"))
+        })?;
+
+        if leverage_array.is_empty() {
+            return Err(Error::from(ParseError::missing_field_owned(format!(
+                "No leverage info found for symbol: {}",
+                symbol
+            ))));
+        }
+
+        let lever_str = leverage_array[0]["lever"]
+            .as_str()
+            .ok_or_else(|| Error::from(ParseError::missing_field("lever")))?;
+
+        lever_str.parse::<f64>().map(|v| v as u32).map_err(|_| {
+            Error::from(ParseError::invalid_value(
+                "lever",
+                format!("Cannot parse leverage: {}", lever_str),
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_leverage_parse() {
+        // Test that leverage string parsing works
+        let lever_str = "10";
+        let leverage: u32 = lever_str.parse::<f64>().unwrap() as u32;
+        assert_eq!(leverage, 10);
+
+        let lever_str = "5.00";
+        let leverage: u32 = lever_str.parse::<f64>().unwrap() as u32;
+        assert_eq!(leverage, 5);
+    }
+}

--- a/ccxt-exchanges/src/okx/rest/futures/margin.rs
+++ b/ccxt-exchanges/src/okx/rest/futures/margin.rs
@@ -1,0 +1,59 @@
+//! Margin mode operations for OKX futures/swap.
+
+use super::super::super::{Okx, signed_request::HttpMethod};
+use ccxt_core::{Error, Result};
+
+impl Okx {
+    /// Set margin mode (cross or isolated) for a symbol.
+    ///
+    /// Uses OKX POST `/api/v5/account/set-position-mode` for position mode,
+    /// and the leverage endpoint implicitly sets margin mode.
+    ///
+    /// Note: OKX sets margin mode per-instrument via the set-leverage endpoint's
+    /// `mgnMode` parameter. This method provides a dedicated interface.
+    pub async fn set_margin_mode_impl(&self, symbol: &str, mode: &str) -> Result<()> {
+        let inst_id = Self::symbol_to_inst_id(symbol);
+
+        let mgn_mode = match mode.to_lowercase().as_str() {
+            "isolated" => "isolated",
+            "cross" | "crossed" => "cross",
+            _ => {
+                return Err(Error::invalid_request(format!(
+                    "Invalid margin mode: {}. Must be 'isolated' or 'cross'",
+                    mode
+                )));
+            }
+        };
+
+        // OKX sets margin mode through the set-leverage endpoint
+        // We need to get current leverage first, then re-set it with the new margin mode
+        let current_leverage = self.get_leverage_impl(symbol).await.unwrap_or(10);
+
+        let mut builder = self
+            .signed_request("/api/v5/account/set-leverage")
+            .method(HttpMethod::Post)
+            .param("instId", &inst_id)
+            .param("lever", current_leverage.to_string())
+            .param("mgnMode", mgn_mode);
+
+        if mgn_mode == "isolated" {
+            builder = builder.param("posSide", "net");
+        }
+
+        let data = builder.execute().await?;
+
+        // Check for nested error
+        if let Some(arr) = data["data"].as_array() {
+            if let Some(first) = arr.first() {
+                if let Some(code) = first["sCode"].as_str() {
+                    if code != "0" {
+                        let msg = first["sMsg"].as_str().unwrap_or("Unknown error");
+                        return Err(Error::exchange(code, msg));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/ccxt-exchanges/src/okx/rest/futures/mod.rs
+++ b/ccxt-exchanges/src/okx/rest/futures/mod.rs
@@ -1,0 +1,9 @@
+//! OKX futures/swap operations.
+//!
+//! This module contains methods for managing positions, leverage,
+//! funding rates, and margin mode for OKX perpetual swaps and futures contracts.
+
+mod funding;
+mod leverage;
+mod margin;
+mod positions;

--- a/ccxt-exchanges/src/okx/rest/futures/positions.rs
+++ b/ccxt-exchanges/src/okx/rest/futures/positions.rs
@@ -1,0 +1,213 @@
+//! Position management methods for OKX futures/swap.
+
+use super::super::super::{Okx, parser};
+use ccxt_core::{Error, ParseError, Result, types::Position};
+use tracing::warn;
+
+impl Okx {
+    /// Map a unified symbol to OKX instType parameter.
+    ///
+    /// Returns the appropriate instType for the given symbol:
+    /// - Symbols with `:` and expiry date → "FUTURES"
+    /// - Symbols with `:` (perpetual) → "SWAP"
+    /// - Otherwise → "SWAP" (default for contract queries)
+    pub(crate) fn inst_type_from_symbol(symbol: &str) -> &'static str {
+        if symbol.contains(':') {
+            // Check if it has an expiry date (e.g., BTC/USDT:USDT-241231)
+            if symbol.contains('-')
+                && symbol
+                    .rsplit('-')
+                    .next()
+                    .is_some_and(|s| s.len() == 6 && s.chars().all(|c| c.is_ascii_digit()))
+            {
+                "FUTURES"
+            } else {
+                "SWAP"
+            }
+        } else {
+            "SWAP"
+        }
+    }
+
+    /// Convert a unified symbol to OKX instId.
+    ///
+    /// Examples:
+    /// - "BTC/USDT:USDT" → "BTC-USDT-SWAP"
+    /// - "BTC/USD:BTC" → "BTC-USD-SWAP"
+    /// - "BTC/USDT" → "BTC-USDT"
+    pub(crate) fn symbol_to_inst_id(symbol: &str) -> String {
+        if let Some(pos) = symbol.find(':') {
+            let base_quote = &symbol[..pos];
+            let settle_part = &symbol[pos + 1..];
+            let base_quote_dash = base_quote.replace('/', "-");
+
+            if let Some(dash_pos) = settle_part.find('-') {
+                // Futures with expiry: BTC/USDT:USDT-241231 → BTC-USDT-241231
+                let expiry = &settle_part[dash_pos + 1..];
+                format!("{}-{}", base_quote_dash, expiry)
+            } else {
+                // Perpetual swap: BTC/USDT:USDT → BTC-USDT-SWAP
+                format!("{}-SWAP", base_quote_dash)
+            }
+        } else {
+            // Spot: BTC/USDT → BTC-USDT
+            symbol.replace('/', "-")
+        }
+    }
+
+    /// Fetch a single position for a symbol.
+    ///
+    /// Uses OKX GET `/api/v5/account/positions` endpoint.
+    pub async fn fetch_position_impl(&self, symbol: &str) -> Result<Position> {
+        let inst_id = Self::symbol_to_inst_id(symbol);
+        let inst_type = Self::inst_type_from_symbol(symbol);
+
+        let data = self
+            .signed_request("/api/v5/account/positions")
+            .param("instId", &inst_id)
+            .param("instType", inst_type)
+            .execute()
+            .await?;
+
+        let positions_array = data["data"].as_array().ok_or_else(|| {
+            Error::from(ParseError::invalid_format("data", "Expected data array"))
+        })?;
+
+        if positions_array.is_empty() {
+            return Err(Error::from(ParseError::missing_field_owned(format!(
+                "No position found for symbol: {}",
+                symbol
+            ))));
+        }
+
+        parser::parse_position(&positions_array[0], symbol)
+    }
+
+    /// Fetch positions for specific symbols, or all positions if empty.
+    ///
+    /// Uses OKX GET `/api/v5/account/positions` endpoint.
+    pub async fn fetch_positions_impl(&self, symbols: &[&str]) -> Result<Vec<Position>> {
+        let inst_type = if symbols.is_empty() {
+            // Fetch all — use the configured default type
+            self.get_inst_type()
+        } else {
+            Self::inst_type_from_symbol(symbols[0])
+        };
+
+        let mut builder = self
+            .signed_request("/api/v5/account/positions")
+            .param("instType", inst_type);
+
+        // OKX supports filtering by instId (comma-separated for up to 10)
+        if !symbols.is_empty() && symbols.len() <= 10 {
+            let inst_ids: Vec<String> =
+                symbols.iter().map(|s| Self::symbol_to_inst_id(s)).collect();
+            builder = builder.param("instId", inst_ids.join(","));
+        }
+
+        let data = builder.execute().await?;
+
+        let positions_array = data["data"].as_array().ok_or_else(|| {
+            Error::from(ParseError::invalid_format("data", "Expected data array"))
+        })?;
+
+        let mut positions = Vec::new();
+        for position_data in positions_array {
+            let inst_id = position_data["instId"].as_str().unwrap_or_default();
+            // Derive symbol from instId for parsing
+            let symbol_hint = Self::inst_id_to_symbol_hint(inst_id);
+
+            match parser::parse_position(position_data, &symbol_hint) {
+                Ok(position) => {
+                    // Filter by requested symbols if specified
+                    if symbols.is_empty() || symbols.contains(&position.symbol.as_str()) {
+                        positions.push(position);
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, inst_id = %inst_id, "Failed to parse OKX position");
+                }
+            }
+        }
+
+        Ok(positions)
+    }
+
+    /// Convert an OKX instId back to a rough unified symbol hint.
+    ///
+    /// This is a best-effort conversion used when market data isn't loaded.
+    /// - "BTC-USDT-SWAP" → "BTC/USDT:USDT"
+    /// - "BTC-USD-SWAP" → "BTC/USD:BTC"
+    /// - "BTC-USDT-241231" → "BTC/USDT:USDT-241231"
+    /// - "BTC-USDT" → "BTC/USDT"
+    fn inst_id_to_symbol_hint(inst_id: &str) -> String {
+        let parts: Vec<&str> = inst_id.split('-').collect();
+        match parts.len() {
+            2 => {
+                // Spot: BTC-USDT → BTC/USDT
+                format!("{}/{}", parts[0], parts[1])
+            }
+            3 if parts[2] == "SWAP" => {
+                // Perpetual: BTC-USDT-SWAP → BTC/USDT:USDT or BTC/USD:BTC
+                let settle = if parts[1] == "USD" {
+                    parts[0]
+                } else {
+                    parts[1]
+                };
+                format!("{}/{}:{}", parts[0], parts[1], settle)
+            }
+            3 => {
+                // Futures with expiry: BTC-USDT-241231 → BTC/USDT:USDT-241231
+                let settle = if parts[1] == "USD" {
+                    parts[0]
+                } else {
+                    parts[1]
+                };
+                format!("{}/{}:{}-{}", parts[0], parts[1], settle, parts[2])
+            }
+            _ => inst_id.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_inst_type_from_symbol() {
+        assert_eq!(Okx::inst_type_from_symbol("BTC/USDT:USDT"), "SWAP");
+        assert_eq!(Okx::inst_type_from_symbol("BTC/USD:BTC"), "SWAP");
+        assert_eq!(
+            Okx::inst_type_from_symbol("BTC/USDT:USDT-241231"),
+            "FUTURES"
+        );
+        assert_eq!(Okx::inst_type_from_symbol("BTC/USDT"), "SWAP");
+    }
+
+    #[test]
+    fn test_symbol_to_inst_id() {
+        assert_eq!(Okx::symbol_to_inst_id("BTC/USDT:USDT"), "BTC-USDT-SWAP");
+        assert_eq!(Okx::symbol_to_inst_id("BTC/USD:BTC"), "BTC-USD-SWAP");
+        assert_eq!(
+            Okx::symbol_to_inst_id("BTC/USDT:USDT-241231"),
+            "BTC-USDT-241231"
+        );
+        assert_eq!(Okx::symbol_to_inst_id("BTC/USDT"), "BTC-USDT");
+        assert_eq!(Okx::symbol_to_inst_id("ETH/USD:ETH"), "ETH-USD-SWAP");
+    }
+
+    #[test]
+    fn test_inst_id_to_symbol_hint() {
+        assert_eq!(
+            Okx::inst_id_to_symbol_hint("BTC-USDT-SWAP"),
+            "BTC/USDT:USDT"
+        );
+        assert_eq!(Okx::inst_id_to_symbol_hint("BTC-USD-SWAP"), "BTC/USD:BTC");
+        assert_eq!(
+            Okx::inst_id_to_symbol_hint("BTC-USDT-241231"),
+            "BTC/USDT:USDT-241231"
+        );
+        assert_eq!(Okx::inst_id_to_symbol_hint("BTC-USDT"), "BTC/USDT");
+    }
+}

--- a/ccxt-exchanges/src/okx/rest/mod.rs
+++ b/ccxt-exchanges/src/okx/rest/mod.rs
@@ -3,6 +3,7 @@
 //! Implements all REST API endpoint operations for the OKX exchange.
 
 mod account;
+pub mod futures;
 mod market_data;
 mod trading;
 

--- a/ccxt-exchanges/src/okx/ws_exchange_impl.rs
+++ b/ccxt-exchanges/src/okx/ws_exchange_impl.rs
@@ -100,21 +100,24 @@ impl WsExchange for Okx {
     // ==================== Private Data Streams ====================
 
     async fn watch_balance(&self) -> Result<MessageStream<Balance>> {
-        Err(Error::not_implemented(
-            "watch_balance not yet implemented for OKX",
-        ))
+        let ws = self.create_private_ws();
+        let auth = self.get_auth()?;
+        ws.login(&auth).await?;
+        ws.watch_balance().await
     }
 
-    async fn watch_orders(&self, _symbol: Option<&str>) -> Result<MessageStream<Order>> {
-        Err(Error::not_implemented(
-            "watch_orders not yet implemented for OKX",
-        ))
+    async fn watch_orders(&self, symbol: Option<&str>) -> Result<MessageStream<Order>> {
+        let ws = self.create_private_ws();
+        let auth = self.get_auth()?;
+        ws.login(&auth).await?;
+        ws.watch_orders(symbol.map(ToString::to_string)).await
     }
 
-    async fn watch_my_trades(&self, _symbol: Option<&str>) -> Result<MessageStream<Trade>> {
-        Err(Error::not_implemented(
-            "watch_my_trades not yet implemented for OKX",
-        ))
+    async fn watch_my_trades(&self, symbol: Option<&str>) -> Result<MessageStream<Trade>> {
+        let ws = self.create_private_ws();
+        let auth = self.get_auth()?;
+        ws.login(&auth).await?;
+        ws.watch_my_trades(symbol.map(ToString::to_string)).await
     }
 
     // ==================== Subscription Management ====================


### PR DESCRIPTION
- Add futures modules for both Bitget and OKX exchanges
- Implement position parsing functions for both exchanges with comprehensive field mapping
- Add funding rate and funding rate history parsers for both exchanges
- Create helper function for parsing f64 fields from JSON values
- Add private WebSocket methods for authentication and order/balance tracking
- Implement message detection helpers for account and order updates
- Add comprehensive unit tests for position and funding rate parsing
- Include rate limiter updates for Binance with new weight field
- Add margin implementation modules for both exchanges
- Implement private WebSocket creation methods for both exchanges
- Add symbol module for Bitget exchange